### PR TITLE
Consistent format for missing start times

### DIFF
--- a/event/asg/1984AS.EVE
+++ b/event/asg/1984AS.EVE
@@ -5,7 +5,7 @@ info,hometeam,NLS
 info,date,1984/07/10
 info,site,SFO02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,weyel901

--- a/event/asg/1985AS.EVE
+++ b/event/asg/1985AS.EVE
@@ -5,7 +5,7 @@ info,hometeam,ALS
 info,date,1985/07/16
 info,site,MIN03
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,true
 info,umphome,mccol901

--- a/event/asg/1986AS.EVE
+++ b/event/asg/1986AS.EVE
@@ -5,7 +5,7 @@ info,hometeam,NLS
 info,date,1986/07/15
 info,site,HOU02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,froeb901

--- a/event/asg/1987AS.EVE
+++ b/event/asg/1987AS.EVE
@@ -5,7 +5,7 @@ info,hometeam,ALS
 info,date,1987/07/14
 info,site,OAK01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,true
 info,umphome,denkd901

--- a/event/asg/1988AS.EVE
+++ b/event/asg/1988AS.EVE
@@ -5,7 +5,7 @@ info,hometeam,NLS
 info,date,1988/07/12
 info,site,CIN08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,pullf901

--- a/event/asg/1989AS.EVE
+++ b/event/asg/1989AS.EVE
@@ -5,7 +5,7 @@ info,hometeam,ALS
 info,date,1989/07/11
 info,site,ANA01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,true
 info,umphome,evanj901

--- a/event/asg/1990AS.EVE
+++ b/event/asg/1990AS.EVE
@@ -5,7 +5,7 @@ info,hometeam,NLS
 info,date,1990/07/10
 info,site,CHI11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,monte901

--- a/event/asg/1991AS.EVE
+++ b/event/asg/1991AS.EVE
@@ -5,7 +5,7 @@ info,hometeam,ALS
 info,date,1991/07/09
 info,site,TOR02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,true
 info,umphome,brinj901

--- a/event/asg/1992AS.EVE
+++ b/event/asg/1992AS.EVE
@@ -5,7 +5,7 @@ info,hometeam,NLS
 info,date,1992/07/14
 info,site,SAN01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,harvd901

--- a/event/asg/1993AS.EVE
+++ b/event/asg/1993AS.EVE
@@ -5,7 +5,7 @@ info,hometeam,ALS
 info,date,1993/07/13
 info,site,BAL12
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,true
 info,umphome,mckej901

--- a/event/asg/1994AS.EVE
+++ b/event/asg/1994AS.EVE
@@ -5,7 +5,7 @@ info,hometeam,NLS
 info,date,1994/07/12
 info,site,PIT07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,rungp901

--- a/event/asg/1995AS.EVE
+++ b/event/asg/1995AS.EVE
@@ -5,7 +5,7 @@ info,hometeam,ALS
 info,date,1995/07/11
 info,site,ARL02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,true
 info,umphome,merrd901

--- a/event/asg/1997AS.EVE
+++ b/event/asg/1997AS.EVE
@@ -5,7 +5,7 @@ info,hometeam,ALS
 info,date,1997/07/08
 info,site,CLE08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,true
 info,umphome,barnl901

--- a/event/post/1983NLCS.EVE
+++ b/event/post/1983NLCS.EVE
@@ -6,7 +6,7 @@ info,hometeam,LAN
 info,date,1983/10/04
 info,site,LOS03
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,unknown
 info,usedh,false
 info,umphome,tatat901
@@ -152,7 +152,7 @@ info,hometeam,LAN
 info,date,1983/10/05
 info,site,LOS03
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,unknown
 info,usedh,false
 info,umphome,steld901
@@ -304,7 +304,7 @@ info,hometeam,PHI
 info,date,1983/10/07
 info,site,PHI12
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mcshj901

--- a/event/post/1984WS.EVE
+++ b/event/post/1984WS.EVE
@@ -5,7 +5,7 @@ info,hometeam,SDN
 info,date,1984/10/09
 info,site,SAN01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,harvd901
@@ -157,7 +157,7 @@ info,hometeam,SDN
 info,date,1984/10/10
 info,site,SAN01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,barnl901
@@ -318,7 +318,7 @@ info,hometeam,DET
 info,date,1984/10/12
 info,site,DET04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,true
 info,umphome,froeb901
@@ -472,7 +472,7 @@ info,hometeam,DET
 info,date,1984/10/13
 info,site,DET04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,true
 info,umphome,garcr901
@@ -619,7 +619,7 @@ info,hometeam,DET
 info,date,1984/10/14
 info,site,DET04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,true
 info,umphome,rungp901

--- a/event/post/1986NLCS.EVE
+++ b/event/post/1986NLCS.EVE
@@ -743,7 +743,7 @@ info,hometeam,HOU
 info,date,1986/10/15
 info,site,HOU02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,brocf901

--- a/event/post/1986WS.EVE
+++ b/event/post/1986WS.EVE
@@ -5,7 +5,7 @@ info,hometeam,NYN
 info,date,1986/10/18
 info,site,NYC17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,kiblj901

--- a/event/post/1996ALCS.EVE
+++ b/event/post/1996ALCS.EVE
@@ -508,7 +508,7 @@ info,hometeam,BAL
 info,date,1996/10/12
 info,site,BAL12
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,true
 info,umphome,morrd901

--- a/event/post/1996ALD2.EVE
+++ b/event/post/1996ALD2.EVE
@@ -521,7 +521,7 @@ info,hometeam,CLE
 info,date,1996/10/05
 info,site,CLE08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,true
 info,umphome,younl901

--- a/event/post/1996NLD2.EVE
+++ b/event/post/1996NLD2.EVE
@@ -5,7 +5,7 @@ info,hometeam,LAN
 info,date,1996/10/02
 info,site,LOS03
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,ripps901

--- a/event/regular/1921CIN.EVN
+++ b/event/regular/1921CIN.EVN
@@ -1802,7 +1802,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1921/05/30
 info,number,1
-info,starttime,0:00AM
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hartb901
@@ -9131,7 +9131,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1921/10/02
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,holmd102

--- a/event/regular/1921PHI.EVN
+++ b/event/regular/1921PHI.EVN
@@ -4539,7 +4539,7 @@ info,visteam,BSN
 info,hometeam,PHI
 info,date,1921/07/04
 info,number,1
-info,starttime,0:00AM
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"450"
@@ -8889,7 +8889,7 @@ info,visteam,BSN
 info,hometeam,PHI
 info,date,1921/09/03
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"450"

--- a/event/regular/1922BOS.EVA
+++ b/event/regular/1922BOS.EVA
@@ -4668,7 +4668,7 @@ info,hometeam,BOS
 info,date,1922/09/28
 info,site,BOS07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,umphome,connt901
 info,ump1b,evanb901

--- a/event/regular/1922BRO.EVN
+++ b/event/regular/1922BRO.EVN
@@ -7237,7 +7237,7 @@ info,hometeam,BRO
 info,date,1922/08/30
 info,site,NYC15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,sentp101
@@ -7390,7 +7390,7 @@ info,hometeam,BRO
 info,date,1922/09/01
 info,site,NYC15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,sentp101
@@ -7576,7 +7576,7 @@ info,hometeam,BRO
 info,date,1922/09/03
 info,site,NYC15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mccob104
@@ -7709,7 +7709,7 @@ info,hometeam,BRO
 info,date,1922/09/09
 info,site,NYC15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,sentp101
@@ -7886,7 +7886,7 @@ info,hometeam,BRO
 info,date,1922/09/10
 info,site,NYC15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,klemb901
@@ -8038,7 +8038,7 @@ info,hometeam,BRO
 info,date,1922/09/13
 info,site,NYC15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,sentp101
@@ -8161,7 +8161,7 @@ info,hometeam,BRO
 info,date,1922/09/14
 info,site,NYC15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,klemb901
@@ -8303,7 +8303,7 @@ info,hometeam,BRO
 info,date,1922/09/15
 info,site,NYC15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,sentp101
@@ -8443,7 +8443,7 @@ info,hometeam,BRO
 info,date,1922/09/16
 info,site,NYC15
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,klemb901
@@ -8588,7 +8588,7 @@ info,hometeam,BRO
 info,date,1922/09/16
 info,site,NYC15
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,klemb901
@@ -8717,7 +8717,7 @@ info,hometeam,BRO
 info,date,1922/09/17
 info,site,NYC15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,klemb901
@@ -8859,7 +8859,7 @@ info,hometeam,BRO
 info,date,1922/09/18
 info,site,NYC15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,klemb901
@@ -9010,7 +9010,7 @@ info,hometeam,BRO
 info,date,1922/09/20
 info,site,NYC15
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,riglc901
@@ -9143,7 +9143,7 @@ info,hometeam,BRO
 info,date,1922/09/20
 info,site,NYC15
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,riglc901
@@ -9313,7 +9313,7 @@ info,hometeam,BRO
 info,date,1922/09/21
 info,site,NYC15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,riglc901
@@ -9445,7 +9445,7 @@ info,hometeam,BRO
 info,date,1922/09/22
 info,site,NYC15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,riglc901
@@ -9590,7 +9590,7 @@ info,hometeam,BRO
 info,date,1922/09/23
 info,site,NYC15
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,riglc901
@@ -9729,7 +9729,7 @@ info,hometeam,BRO
 info,date,1922/09/23
 info,site,NYC15
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,quige901
@@ -9860,7 +9860,7 @@ info,hometeam,BRO
 info,date,1922/09/24
 info,site,NYC15
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,riglc901
@@ -9990,7 +9990,7 @@ info,hometeam,BRO
 info,date,1922/09/24
 info,site,NYC15
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,quige901
@@ -10135,7 +10135,7 @@ info,hometeam,BRO
 info,date,1922/10/01
 info,site,NYC15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mccob104

--- a/event/regular/1922BSN.EVN
+++ b/event/regular/1922BSN.EVN
@@ -5251,7 +5251,7 @@ info,hometeam,BSN
 info,date,1922/09/05
 info,site,BOS08
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,sentp101
@@ -5388,7 +5388,7 @@ info,hometeam,BSN
 info,date,1922/09/05
 info,site,BOS08
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,klemb901
@@ -5518,7 +5518,7 @@ info,hometeam,BSN
 info,date,1922/09/06
 info,site,BOS08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,sentp101
@@ -6459,7 +6459,7 @@ info,hometeam,BSN
 info,date,1922/09/23
 info,site,BOS08
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hartb901
@@ -6601,7 +6601,7 @@ info,hometeam,BSN
 info,date,1922/09/26
 info,site,BOS08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,westf901
@@ -6746,7 +6746,7 @@ info,hometeam,BSN
 info,date,1922/09/27
 info,site,BOS08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hartb901

--- a/event/regular/1922CHA.EVA
+++ b/event/regular/1922CHA.EVA
@@ -8109,7 +8109,7 @@ info,hometeam,CHA
 info,date,1922/09/14
 info,site,CHI10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,umphome,dinnb101
 info,ump1b,chilo901
@@ -8240,7 +8240,7 @@ info,hometeam,CHA
 info,date,1922/09/15
 info,site,CHI10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,umphome,hildg101
 info,ump1b,chilo901

--- a/event/regular/1922CIN.EVN
+++ b/event/regular/1922CIN.EVN
@@ -4675,7 +4675,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1922/07/02
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,odayh101
@@ -8638,7 +8638,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1922/08/26
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mccob104

--- a/event/regular/1922DET.EVA
+++ b/event/regular/1922DET.EVA
@@ -4458,7 +4458,7 @@ info,hometeam,DET
 info,date,1922/09/21
 info,site,DET04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,umphome,evanb901
 info,ump1b,owenb901

--- a/event/regular/1922NY1.EVN
+++ b/event/regular/1922NY1.EVN
@@ -7091,7 +7091,7 @@ info,hometeam,NY1
 info,date,1922/09/02
 info,site,NYC14
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,sentp101
@@ -7228,7 +7228,7 @@ info,hometeam,NY1
 info,date,1922/09/02
 info,site,NYC14
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,klemb901
@@ -7359,7 +7359,7 @@ info,hometeam,NY1
 info,date,1922/09/03
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,klemb901
@@ -7504,7 +7504,7 @@ info,hometeam,NY1
 info,date,1922/09/11
 info,site,NYC14
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mccob104
@@ -7656,7 +7656,7 @@ info,hometeam,NY1
 info,date,1922/09/11
 info,site,NYC14
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,sentp101
@@ -7807,7 +7807,7 @@ info,hometeam,NY1
 info,date,1922/09/13
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mccob104
@@ -7953,7 +7953,7 @@ info,hometeam,NY1
 info,date,1922/09/14
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hartb901
@@ -8125,7 +8125,7 @@ info,hometeam,NY1
 info,date,1922/09/15
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mccob104
@@ -8286,7 +8286,7 @@ info,hometeam,NY1
 info,date,1922/09/16
 info,site,NYC14
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,riglc901
@@ -8428,7 +8428,7 @@ info,hometeam,NY1
 info,date,1922/09/16
 info,site,NYC14
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,quige901
@@ -8574,7 +8574,7 @@ info,hometeam,NY1
 info,date,1922/09/17
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,riglc901
@@ -8708,7 +8708,7 @@ info,hometeam,NY1
 info,date,1922/09/18
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,quige901
@@ -8845,7 +8845,7 @@ info,hometeam,NY1
 info,date,1922/09/20
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,klemb901
@@ -8980,7 +8980,7 @@ info,hometeam,NY1
 info,date,1922/09/21
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,quige901
@@ -9130,7 +9130,7 @@ info,hometeam,NY1
 info,date,1922/09/22
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,klemb901
@@ -9303,7 +9303,7 @@ info,hometeam,NY1
 info,date,1922/09/23
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,sentp101
@@ -9446,7 +9446,7 @@ info,hometeam,NY1
 info,date,1922/09/24
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,klemb901
@@ -9602,7 +9602,7 @@ info,hometeam,NY1
 info,date,1922/09/25
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,riglc901
@@ -9750,7 +9750,7 @@ info,hometeam,NY1
 info,date,1922/09/26
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,klemb901
@@ -9882,7 +9882,7 @@ info,hometeam,NY1
 info,date,1922/09/27
 info,site,NYC14
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mccob104
@@ -10021,7 +10021,7 @@ info,hometeam,NY1
 info,date,1922/09/27
 info,site,NYC14
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,riglc901
@@ -10169,7 +10169,7 @@ info,hometeam,NY1
 info,date,1922/10/01
 info,site,NYC14
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,osulj901

--- a/event/regular/1922NYA.EVA
+++ b/event/regular/1922NYA.EVA
@@ -8945,7 +8945,7 @@ info,hometeam,NYA
 info,date,1922/08/25
 info,site,NYC14
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,umphome,morig101
 info,ump1b,evanb901
@@ -9093,7 +9093,7 @@ info,hometeam,NYA
 info,date,1922/08/26
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,umphome,evanb901
 info,ump1b,morig101
@@ -9236,7 +9236,7 @@ info,hometeam,NYA
 info,date,1922/08/28
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,umphome,morig101
 info,ump1b,evanb901
@@ -9374,7 +9374,7 @@ info,hometeam,NYA
 info,date,1922/08/29
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,umphome,nalld901
 info,ump1b,connt901
@@ -9518,7 +9518,7 @@ info,hometeam,NYA
 info,date,1922/08/30
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,umphome,connt901
 info,ump1b,nalld901
@@ -9657,7 +9657,7 @@ info,hometeam,NYA
 info,date,1922/09/05
 info,site,NYC14
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,umphome,evanb901
 info,ump1b,hildg101
@@ -9795,7 +9795,7 @@ info,hometeam,NYA
 info,date,1922/09/05
 info,site,NYC14
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,umphome,hildg101
 info,ump1b,evanb901
@@ -9943,7 +9943,7 @@ info,hometeam,NYA
 info,date,1922/09/06
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,umphome,evanb901
 info,ump1b,hildg101
@@ -10083,7 +10083,7 @@ info,hometeam,NYA
 info,date,1922/09/08
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,umphome,connt901
 info,ump1b,nalld901
@@ -10226,7 +10226,7 @@ info,hometeam,NYA
 info,date,1922/09/09
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,umphome,nalld901
 info,ump1b,connt901
@@ -10355,7 +10355,7 @@ info,hometeam,NYA
 info,date,1922/09/10
 info,site,NYC14
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,umphome,evanb901
 info,ump1b,hildg101

--- a/event/regular/1922PHA.EVA
+++ b/event/regular/1922PHA.EVA
@@ -2939,7 +2939,7 @@ info,hometeam,PHA
 info,date,1922/06/27
 info,site,PHI11
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dinnb101
@@ -4060,7 +4060,7 @@ info,hometeam,PHA
 info,date,1922/07/04
 info,site,PHI11
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hildg101
@@ -6954,7 +6954,7 @@ info,hometeam,PHA
 info,date,1922/08/19
 info,site,PHI11
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,owenb901
@@ -7380,7 +7380,7 @@ info,hometeam,PHA
 info,date,1922/08/22
 info,site,PHI11
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,guthb901
@@ -8754,7 +8754,7 @@ info,hometeam,PHA
 info,date,1922/09/02
 info,site,PHI11
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,umphome,evanb901
 info,ump1b,hildg101
@@ -8906,7 +8906,7 @@ info,hometeam,PHA
 info,date,1922/09/02
 info,site,PHI11
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,umphome,hildg101
 info,ump1b,evanb901
@@ -9034,7 +9034,7 @@ info,hometeam,PHA
 info,date,1922/09/11
 info,site,PHI11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,umphome,evanb901
 info,ump1b,hildg101
@@ -9190,7 +9190,7 @@ info,hometeam,PHA
 info,date,1922/09/28
 info,site,PHI11
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,owenb901
@@ -9482,7 +9482,7 @@ info,hometeam,PHA
 info,date,1922/09/29
 info,site,PHI11
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,owenb901
@@ -9775,7 +9775,7 @@ info,hometeam,PHA
 info,date,1922/09/30
 info,site,PHI11
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,owenb901

--- a/event/regular/1922PHI.EVN
+++ b/event/regular/1922PHI.EVN
@@ -3826,7 +3826,7 @@ info,hometeam,PHI
 info,date,1922/06/24
 info,site,PHI09
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mccob104
@@ -5569,7 +5569,7 @@ info,hometeam,PHI
 info,date,1922/09/04
 info,site,PHI09
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hartb901
@@ -5911,7 +5911,7 @@ info,hometeam,PHI
 info,date,1922/09/05
 info,site,PHI09
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hartb901
@@ -6057,7 +6057,7 @@ info,hometeam,PHI
 info,date,1922/09/05
 info,site,PHI09
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mccob104
@@ -6208,7 +6208,7 @@ info,hometeam,PHI
 info,date,1922/09/06
 info,site,PHI09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hartb901
@@ -6339,7 +6339,7 @@ info,hometeam,PHI
 info,date,1922/09/07
 info,site,PHI09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,klemb901
@@ -6500,7 +6500,7 @@ info,hometeam,PHI
 info,date,1922/09/08
 info,site,PHI09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mccob104
@@ -6634,7 +6634,7 @@ info,hometeam,PHI
 info,date,1922/09/09
 info,site,PHI09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,klemb901

--- a/event/regular/1922PIT.EVN
+++ b/event/regular/1922PIT.EVN
@@ -2892,7 +2892,7 @@ info,hometeam,PIT
 info,date,1922/05/30
 info,site,PIT06
 info,number,1
-info,starttime,0:00AM
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hartb901
@@ -9575,7 +9575,7 @@ info,hometeam,PIT
 info,date,1922/08/25
 info,site,PIT06
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,morac102
@@ -9730,7 +9730,7 @@ info,hometeam,PIT
 info,date,1922/08/25
 info,site,PIT06
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,quige901
@@ -9876,7 +9876,7 @@ info,hometeam,PIT
 info,date,1922/08/26
 info,site,PIT06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,morac102
@@ -10016,7 +10016,7 @@ info,hometeam,PIT
 info,date,1922/08/28
 info,site,PIT06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,quige901
@@ -10162,7 +10162,7 @@ info,hometeam,PIT
 info,date,1922/08/29
 info,site,PIT06
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,morac102
@@ -10280,7 +10280,7 @@ info,hometeam,PIT
 info,date,1922/08/29
 info,site,PIT06
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,quige901
@@ -10403,7 +10403,7 @@ info,hometeam,PIT
 info,date,1922/09/04
 info,site,PIT06
 info,number,1
-info,starttime,0:00AM
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,riglc901

--- a/event/regular/1922SLA.EVA
+++ b/event/regular/1922SLA.EVA
@@ -1033,7 +1033,7 @@ info,hometeam,SLA
 info,date,1922/05/30
 info,site,STL07
 info,number,1
-info,starttime,0:00AM
+info,starttime,0:00PM
 info,daynight,day
 info,umphome,wilsf901
 info,ump1b,owenb901
@@ -3163,7 +3163,7 @@ info,hometeam,SLA
 info,date,1922/09/17
 info,site,STL07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,umphome,dinnb101
 info,ump1b,guthb901

--- a/event/regular/1922WS1.EVA
+++ b/event/regular/1922WS1.EVA
@@ -3404,7 +3404,7 @@ info,hometeam,WS1
 info,date,1922/10/01
 info,site,WAS09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,umphome,owenb901
 info,ump1b,nalld901

--- a/event/regular/1925PHA.EVA
+++ b/event/regular/1925PHA.EVA
@@ -7676,7 +7676,7 @@ info,hometeam,PHA
 info,date,1925/09/07
 info,site,PHI11
 info,number,1
-info,starttime,00:00AM
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"74"

--- a/event/regular/1927BOS.EVA
+++ b/event/regular/1927BOS.EVA
@@ -3600,7 +3600,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1927/07/04
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,rowlp801

--- a/event/regular/1927CHA.EVA
+++ b/event/regular/1927CHA.EVA
@@ -5421,7 +5421,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1927/07/15
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,nalld901

--- a/event/regular/1927CLE.EVA
+++ b/event/regular/1927CLE.EVA
@@ -4932,7 +4932,7 @@ info,hometeam,CLE
 info,date,1927/07/04
 info,site,CLE06
 info,number,1
-info,starttime,0:00AM
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hildg101

--- a/event/regular/1927PHA.EVA
+++ b/event/regular/1927PHA.EVA
@@ -5696,7 +5696,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1927/08/02
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,geish901
@@ -7827,7 +7827,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1927/09/05
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,evanb901
@@ -8097,7 +8097,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1927/09/06
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mcgob901

--- a/event/regular/1927PHI.EVN
+++ b/event/regular/1927PHI.EVN
@@ -7312,7 +7312,7 @@ info,hometeam,PHI
 info,site,PHI09
 info,date,1927/08/19
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mclap901
@@ -9465,7 +9465,7 @@ info,hometeam,PHI
 info,site,PHI09
 info,date,1927/09/07
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mclap901

--- a/event/regular/1927PIT.EVN
+++ b/event/regular/1927PIT.EVN
@@ -5112,7 +5112,7 @@ info,hometeam,PIT
 info,date,1927/07/04
 info,site,PIT06
 info,number,1
-info,starttime,0:00AM
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,wilsf901
@@ -8305,7 +8305,7 @@ info,hometeam,PIT
 info,date,1927/09/05
 info,site,PIT06
 info,number,1
-info,starttime,0:00AM
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,wilsf901

--- a/event/regular/1930CLE.EVA
+++ b/event/regular/1930CLE.EVA
@@ -2101,7 +2101,7 @@ info,hometeam,CLE
 info,date,1930/05/30
 info,site,CLE06
 info,number,1
-info,starttime,0:00AM
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"39"

--- a/event/regular/1930PHA.EVA
+++ b/event/regular/1930PHA.EVA
@@ -4154,7 +4154,7 @@ info,hometeam,PHA
 info,date,1930/06/20
 info,site,PHI11
 info,number,0
-info,starttime,0:00AM
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"39"

--- a/event/regular/1931BOS.EVA
+++ b/event/regular/1931BOS.EVA
@@ -2717,7 +2717,7 @@ info,hometeam,BOS
 info,date,1931/07/12
 info,site,BOS08
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,umphome,ormsr901
 info,ump1b,guthb901

--- a/event/regular/1931PHI.EVN
+++ b/event/regular/1931PHI.EVN
@@ -1503,7 +1503,7 @@ info,hometeam,PHI
 info,site,PHI09
 info,date,1931/05/15
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stard901
@@ -2727,7 +2727,7 @@ info,hometeam,PHI
 info,date,1931/05/30
 info,site,PHI09
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"74"

--- a/event/regular/1932BOS.EVA
+++ b/event/regular/1932BOS.EVA
@@ -1061,7 +1061,7 @@ info,hometeam,BOS
 info,date,1932/05/12
 info,site,BOS07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -2351,7 +2351,7 @@ info,hometeam,BOS
 info,date,1932/06/30
 info,site,BOS07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"

--- a/event/regular/1932BRO.EVN
+++ b/event/regular/1932BRO.EVN
@@ -1135,7 +1135,7 @@ info,hometeam,BRO
 info,date,1932/05/20
 info,site,NYC15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -1439,7 +1439,7 @@ info,hometeam,BRO
 info,date,1932/05/21
 info,site,NYC15
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98,363"
@@ -2424,7 +2424,7 @@ info,hometeam,BRO
 info,date,1932/06/03
 info,site,NYC15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -3053,7 +3053,7 @@ info,hometeam,BRO
 info,date,1932/06/07
 info,site,NYC15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -3199,7 +3199,7 @@ info,hometeam,BRO
 info,date,1932/06/08
 info,site,NYC15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98,363"
@@ -3401,7 +3401,7 @@ info,hometeam,BRO
 info,date,1932/06/09
 info,site,NYC15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -3527,7 +3527,7 @@ info,hometeam,BRO
 info,date,1932/06/10
 info,site,NYC15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -3663,7 +3663,7 @@ info,hometeam,BRO
 info,date,1932/06/11
 info,site,NYC15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -3818,7 +3818,7 @@ info,hometeam,BRO
 info,date,1932/06/15
 info,site,NYC15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -3944,7 +3944,7 @@ info,hometeam,BRO
 info,date,1932/06/16
 info,site,NYC15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -4222,7 +4222,7 @@ info,hometeam,BRO
 info,date,1932/06/18
 info,site,NYC15
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -4483,7 +4483,7 @@ info,hometeam,BRO
 info,date,1932/06/20
 info,site,NYC15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -4610,7 +4610,7 @@ info,hometeam,BRO
 info,date,1932/06/21
 info,site,NYC15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -4750,7 +4750,7 @@ info,hometeam,BRO
 info,date,1932/06/22
 info,site,NYC15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -5030,7 +5030,7 @@ info,hometeam,BRO
 info,date,1932/06/28
 info,site,NYC15
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -5190,7 +5190,7 @@ info,hometeam,BRO
 info,date,1932/06/28
 info,site,NYC15
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98,363"

--- a/event/regular/1932BSN.EVN
+++ b/event/regular/1932BSN.EVN
@@ -5,7 +5,7 @@ info,hometeam,BSN
 info,date,1932/04/21
 info,site,BOS08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -146,7 +146,7 @@ info,hometeam,BSN
 info,date,1932/04/22
 info,site,BOS08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -286,7 +286,7 @@ info,hometeam,BSN
 info,date,1932/04/23
 info,site,BOS08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -422,7 +422,7 @@ info,hometeam,BSN
 info,date,1932/04/29
 info,site,BOS08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -563,7 +563,7 @@ info,hometeam,BSN
 info,date,1932/04/30
 info,site,BOS08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -853,7 +853,7 @@ info,hometeam,BSN
 info,date,1932/05/23
 info,site,BOS08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -1006,7 +1006,7 @@ info,hometeam,BSN
 info,date,1932/05/24
 info,site,BOS08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -1160,7 +1160,7 @@ info,hometeam,BSN
 info,date,1932/05/25
 info,site,BOS08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -1287,7 +1287,7 @@ info,hometeam,BSN
 info,date,1932/05/31
 info,site,BOS08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -2590,7 +2590,7 @@ info,hometeam,BSN
 info,date,1932/06/23
 info,site,BOS08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -2761,7 +2761,7 @@ info,hometeam,BSN
 info,date,1932/06/24
 info,site,BOS08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -2890,7 +2890,7 @@ info,hometeam,BSN
 info,date,1932/06/25
 info,site,BOS08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"

--- a/event/regular/1932CHA.EVA
+++ b/event/regular/1932CHA.EVA
@@ -3573,7 +3573,7 @@ info,hometeam,CHA
 info,date,1932/06/15
 info,site,CHI10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -3698,7 +3698,7 @@ info,hometeam,CHA
 info,date,1932/06/16
 info,site,CHI10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98,277"
@@ -3851,7 +3851,7 @@ info,hometeam,CHA
 info,date,1932/06/18
 info,site,CHI10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"

--- a/event/regular/1932CHN.EVN
+++ b/event/regular/1932CHN.EVN
@@ -1023,7 +1023,7 @@ info,hometeam,CHN
 info,date,1932/05/05
 info,site,CHI11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -1158,7 +1158,7 @@ info,hometeam,CHN
 info,date,1932/05/06
 info,site,CHI11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98,363"
@@ -1290,7 +1290,7 @@ info,hometeam,CHN
 info,date,1932/05/07
 info,site,CHI11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -1585,7 +1585,7 @@ info,hometeam,CHN
 info,date,1932/05/10
 info,site,CHI11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -1719,7 +1719,7 @@ info,hometeam,CHN
 info,date,1932/05/12
 info,site,CHI11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -2900,7 +2900,7 @@ info,hometeam,CHN
 info,date,1932/05/30
 info,site,CHI11
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"412"

--- a/event/regular/1932CIN.EVN
+++ b/event/regular/1932CIN.EVN
@@ -1122,7 +1122,7 @@ info,hometeam,CIN
 info,date,1932/04/25
 info,site,CIN07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -1252,7 +1252,7 @@ info,hometeam,CIN
 info,date,1932/04/27
 info,site,CIN07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -2566,7 +2566,7 @@ info,hometeam,CIN
 info,date,1932/05/12
 info,site,CIN07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -2698,7 +2698,7 @@ info,hometeam,CIN
 info,date,1932/05/13
 info,site,CIN07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -2837,7 +2837,7 @@ info,hometeam,CIN
 info,date,1932/05/14
 info,site,CIN07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -3122,7 +3122,7 @@ info,hometeam,CIN
 info,date,1932/05/16
 info,site,CIN07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -3253,7 +3253,7 @@ info,hometeam,CIN
 info,date,1932/05/17
 info,site,CIN07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -3392,7 +3392,7 @@ info,hometeam,CIN
 info,date,1932/05/18
 info,site,CIN07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98,509"

--- a/event/regular/1932CLE.EVA
+++ b/event/regular/1932CLE.EVA
@@ -1506,7 +1506,7 @@ info,hometeam,CLE
 info,date,1932/05/04
 info,site,CLE06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -3473,7 +3473,7 @@ info,hometeam,CLE
 info,date,1932/06/11
 info,site,CLE06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -3768,7 +3768,7 @@ info,hometeam,CLE
 info,date,1932/06/13
 info,site,CLE06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98,39"
@@ -3929,7 +3929,7 @@ info,hometeam,CLE
 info,date,1932/06/14
 info,site,CLE06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"

--- a/event/regular/1932DET.EVA
+++ b/event/regular/1932DET.EVA
@@ -2214,7 +2214,7 @@ info,hometeam,DET
 info,date,1932/06/07
 info,site,DET04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -2365,7 +2365,7 @@ info,hometeam,DET
 info,date,1932/06/08
 info,site,DET04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -2518,7 +2518,7 @@ info,hometeam,DET
 info,date,1932/06/09
 info,site,DET04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -2661,7 +2661,7 @@ info,hometeam,DET
 info,date,1932/06/10
 info,site,DET04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -3150,7 +3150,7 @@ info,hometeam,DET
 info,date,1932/06/13
 info,site,DET04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98,467"
@@ -3287,7 +3287,7 @@ info,hometeam,DET
 info,date,1932/06/14
 info,site,DET04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98,467"

--- a/event/regular/1932NY1.EVN
+++ b/event/regular/1932NY1.EVN
@@ -817,7 +817,7 @@ info,hometeam,NY1
 info,date,1932/05/02
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -957,7 +957,7 @@ info,hometeam,NY1
 info,date,1932/05/03
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -1123,7 +1123,7 @@ info,hometeam,NY1
 info,date,1932/05/26
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -1292,7 +1292,7 @@ info,hometeam,NY1
 info,date,1932/05/27
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -1437,7 +1437,7 @@ info,hometeam,NY1
 info,date,1932/05/28
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -1725,7 +1725,7 @@ info,hometeam,NY1
 info,date,1932/06/01
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -1865,7 +1865,7 @@ info,hometeam,NY1
 info,date,1932/06/04
 info,site,NYC14
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -2151,7 +2151,7 @@ info,hometeam,NY1
 info,date,1932/06/07
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -2278,7 +2278,7 @@ info,hometeam,NY1
 info,date,1932/06/08
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -2428,7 +2428,7 @@ info,hometeam,NY1
 info,date,1932/06/09
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -2551,7 +2551,7 @@ info,hometeam,NY1
 info,date,1932/06/10
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -2689,7 +2689,7 @@ info,hometeam,NY1
 info,date,1932/06/11
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -2828,7 +2828,7 @@ info,hometeam,NY1
 info,date,1932/06/15
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -2967,7 +2967,7 @@ info,hometeam,NY1
 info,date,1932/06/16
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -3231,7 +3231,7 @@ info,hometeam,NY1
 info,date,1932/06/18
 info,site,NYC14
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -3360,7 +3360,7 @@ info,hometeam,NY1
 info,date,1932/06/21
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -3499,7 +3499,7 @@ info,hometeam,NY1
 info,date,1932/06/22
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -3627,7 +3627,7 @@ info,hometeam,NY1
 info,date,1932/06/23
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -3767,7 +3767,7 @@ info,hometeam,NY1
 info,date,1932/06/30
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"

--- a/event/regular/1932NYA.EVA
+++ b/event/regular/1932NYA.EVA
@@ -301,7 +301,7 @@ info,hometeam,NYA
 info,date,1932/04/23
 info,site,NYC16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -481,7 +481,7 @@ info,hometeam,NYA
 info,date,1932/04/26
 info,site,NYC16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -636,7 +636,7 @@ info,hometeam,NYA
 info,date,1932/04/28
 info,site,NYC16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -763,7 +763,7 @@ info,hometeam,NYA
 info,date,1932/04/29
 info,site,NYC16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -917,7 +917,7 @@ info,hometeam,NYA
 info,date,1932/04/30
 info,site,NYC16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -1042,7 +1042,7 @@ info,hometeam,NYA
 info,date,1932/05/06
 info,site,NYC16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -1169,7 +1169,7 @@ info,hometeam,NYA
 info,date,1932/05/07
 info,site,NYC16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -1301,7 +1301,7 @@ info,hometeam,NYA
 info,date,1932/05/10
 info,site,NYC16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -1445,7 +1445,7 @@ info,hometeam,NYA
 info,date,1932/05/11
 info,site,NYC16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -1581,7 +1581,7 @@ info,hometeam,NYA
 info,date,1932/05/14
 info,site,NYC16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -1850,7 +1850,7 @@ info,hometeam,NYA
 info,date,1932/05/16
 info,site,NYC16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -1990,7 +1990,7 @@ info,hometeam,NYA
 info,date,1932/05/17
 info,site,NYC16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -2111,7 +2111,7 @@ info,hometeam,NYA
 info,date,1932/05/18
 info,site,NYC16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -2249,7 +2249,7 @@ info,hometeam,NYA
 info,date,1932/05/19
 info,site,NYC16
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -2600,7 +2600,7 @@ info,hometeam,NYA
 info,date,1932/05/20
 info,site,NYC16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -2900,7 +2900,7 @@ info,hometeam,NYA
 info,date,1932/05/21
 info,site,NYC16
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -3181,7 +3181,7 @@ info,hometeam,NYA
 info,date,1932/05/23
 info,site,NYC16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -3329,7 +3329,7 @@ info,hometeam,NYA
 info,date,1932/05/24
 info,site,NYC16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -3619,7 +3619,7 @@ info,hometeam,NYA
 info,date,1932/06/25
 info,site,NYC16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -3895,7 +3895,7 @@ info,hometeam,NYA
 info,date,1932/06/28
 info,site,NYC16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -4033,7 +4033,7 @@ info,hometeam,NYA
 info,date,1932/06/29
 info,site,NYC16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"

--- a/event/regular/1932PHA.EVA
+++ b/event/regular/1932PHA.EVA
@@ -922,7 +922,7 @@ info,hometeam,PHA
 info,date,1932/05/05
 info,site,PHI11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -1356,7 +1356,7 @@ info,hometeam,PHA
 info,date,1932/05/10
 info,site,PHI11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -1481,7 +1481,7 @@ info,hometeam,PHA
 info,date,1932/05/13
 info,site,PHI11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -1626,7 +1626,7 @@ info,hometeam,PHA
 info,date,1932/05/14
 info,site,PHI11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -2987,7 +2987,7 @@ info,hometeam,PHA
 info,date,1932/05/31
 info,site,PHI11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98,467"
@@ -3168,7 +3168,7 @@ info,hometeam,PHA
 info,date,1932/06/01
 info,site,PHI11
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -3511,7 +3511,7 @@ info,hometeam,PHA
 info,date,1932/06/02
 info,site,PHI11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -3679,7 +3679,7 @@ info,hometeam,PHA
 info,date,1932/06/03
 info,site,PHI11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98,340"
@@ -3880,7 +3880,7 @@ info,hometeam,PHA
 info,date,1932/06/04
 info,site,PHI11
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -4341,7 +4341,7 @@ info,hometeam,PHA
 info,date,1932/06/27
 info,site,PHI11
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"

--- a/event/regular/1932PHI.EVN
+++ b/event/regular/1932PHI.EVN
@@ -163,7 +163,7 @@ info,hometeam,PHI
 info,date,1932/04/21
 info,site,PHI09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -290,7 +290,7 @@ info,hometeam,PHI
 info,date,1932/04/22
 info,site,PHI09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -454,7 +454,7 @@ info,hometeam,PHI
 info,date,1932/04/23
 info,site,PHI09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -603,7 +603,7 @@ info,hometeam,PHI
 info,date,1932/04/28
 info,site,PHI09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -767,7 +767,7 @@ info,hometeam,PHI
 info,date,1932/04/29
 info,site,PHI09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -911,7 +911,7 @@ info,hometeam,PHI
 info,date,1932/04/30
 info,site,PHI09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98,363"
@@ -1136,7 +1136,7 @@ info,hometeam,PHI
 info,date,1932/05/04
 info,site,PHI09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -1269,7 +1269,7 @@ info,hometeam,PHI
 info,date,1932/05/23
 info,site,PHI09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -1442,7 +1442,7 @@ info,hometeam,PHI
 info,date,1932/05/24
 info,site,PHI09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98,340"
@@ -2229,7 +2229,7 @@ info,hometeam,PHI
 info,date,1932/06/06
 info,site,PHI09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -4136,7 +4136,7 @@ info,hometeam,PHI
 info,date,1932/06/20
 info,site,PHI09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -4727,7 +4727,7 @@ info,hometeam,PHI
 info,date,1932/06/24
 info,site,PHI09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -4869,7 +4869,7 @@ info,hometeam,PHI
 info,date,1932/06/25
 info,site,PHI09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -5034,7 +5034,7 @@ info,hometeam,PHI
 info,date,1932/06/29
 info,site,PHI09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -5171,7 +5171,7 @@ info,hometeam,PHI
 info,date,1932/06/30
 info,site,PHI09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"

--- a/event/regular/1932PIT.EVN
+++ b/event/regular/1932PIT.EVN
@@ -1345,7 +1345,7 @@ info,hometeam,PIT
 info,date,1932/05/16
 info,site,PIT06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -1495,7 +1495,7 @@ info,hometeam,PIT
 info,date,1932/05/17
 info,site,PIT06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -1619,7 +1619,7 @@ info,hometeam,PIT
 info,date,1932/05/18
 info,site,PIT06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -1746,7 +1746,7 @@ info,hometeam,PIT
 info,date,1932/05/19
 info,site,PIT06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -2169,7 +2169,7 @@ info,hometeam,PIT
 info,date,1932/05/30
 info,site,PIT06
 info,number,1
-info,starttime,0:00AM
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"509"
@@ -2718,7 +2718,7 @@ info,hometeam,PIT
 info,date,1932/06/03
 info,site,PIT06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98,277"

--- a/event/regular/1932SLA.EVA
+++ b/event/regular/1932SLA.EVA
@@ -1684,7 +1684,7 @@ info,hometeam,SLA
 info,date,1932/05/30
 info,site,STL07
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"412"
@@ -4360,7 +4360,7 @@ info,hometeam,SLA
 info,date,1932/07/23
 info,site,STL07
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"412"

--- a/event/regular/1932SLN.EVN
+++ b/event/regular/1932SLN.EVN
@@ -5404,7 +5404,7 @@ info,hometeam,SLN
 info,date,1932/08/18
 info,site,STL07
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"412"

--- a/event/regular/1932WS1.EVA
+++ b/event/regular/1932WS1.EVA
@@ -822,7 +822,7 @@ info,hometeam,WS1
 info,date,1932/05/02
 info,site,WAS09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -979,7 +979,7 @@ info,hometeam,WS1
 info,date,1932/05/03
 info,site,WAS09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -1434,7 +1434,7 @@ info,hometeam,WS1
 info,date,1932/05/09
 info,site,WAS09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -1558,7 +1558,7 @@ info,hometeam,WS1
 info,date,1932/05/13
 info,site,WAS09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -2148,7 +2148,7 @@ info,hometeam,WS1
 info,date,1932/05/26
 info,site,WAS09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"

--- a/event/regular/1933BOS.EVA
+++ b/event/regular/1933BOS.EVA
@@ -5,7 +5,7 @@ info,hometeam,BOS
 info,date,1933/04/21
 info,site,BOS07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dinnb101
@@ -160,7 +160,7 @@ info,hometeam,BOS
 info,date,1933/04/22
 info,site,BOS07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hildg101
@@ -747,7 +747,7 @@ info,hometeam,BOS
 info,date,1933/05/16
 info,site,BOS07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,morig101
@@ -2809,7 +2809,7 @@ info,hometeam,BOS
 info,date,1933/06/13
 info,site,BOS07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dinnb101
@@ -2950,7 +2950,7 @@ info,hometeam,BOS
 info,date,1933/06/14
 info,site,BOS07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dinnb101
@@ -3122,7 +3122,7 @@ info,hometeam,BOS
 info,date,1933/06/15
 info,site,BOS07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,summb901
@@ -3279,7 +3279,7 @@ info,hometeam,BOS
 info,date,1933/06/17
 info,site,BOS07
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,vangr901
@@ -5070,7 +5070,7 @@ info,hometeam,BOS
 info,date,1933/07/26
 info,site,BOS07
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,summb901
@@ -5210,7 +5210,7 @@ info,hometeam,BOS
 info,date,1933/07/26
 info,site,BOS07
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mcgob901
@@ -5791,7 +5791,7 @@ info,hometeam,BOS
 info,date,1933/08/10
 info,site,BOS07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,summb901
@@ -5940,7 +5940,7 @@ info,hometeam,BOS
 info,date,1933/08/11
 info,site,BOS07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mcgob901
@@ -6421,7 +6421,7 @@ info,hometeam,BOS
 info,date,1933/09/05
 info,site,BOS07
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dinnb101
@@ -6587,7 +6587,7 @@ info,hometeam,BOS
 info,date,1933/09/08
 info,site,BOS07
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,ormsr901
@@ -7413,7 +7413,7 @@ info,hometeam,BOS
 info,date,1933/09/23
 info,site,BOS07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,morig101

--- a/event/regular/1933BRO.EVN
+++ b/event/regular/1933BRO.EVN
@@ -188,7 +188,7 @@ info,hometeam,BRO
 info,date,1933/04/20
 info,site,NYC15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -362,7 +362,7 @@ info,hometeam,BRO
 info,date,1933/04/22
 info,site,NYC15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -643,7 +643,7 @@ info,hometeam,BRO
 info,date,1933/04/26
 info,site,NYC15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -774,7 +774,7 @@ info,hometeam,BRO
 info,date,1933/04/27
 info,site,NYC15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -894,7 +894,7 @@ info,hometeam,BRO
 info,date,1933/04/29
 info,site,NYC15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -1188,7 +1188,7 @@ info,hometeam,BRO
 info,date,1933/05/02
 info,site,NYC15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -1353,7 +1353,7 @@ info,hometeam,BRO
 info,date,1933/05/04
 info,site,NYC15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -1493,7 +1493,7 @@ info,hometeam,BRO
 info,date,1933/05/05
 info,site,NYC15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -1930,7 +1930,7 @@ info,hometeam,BRO
 info,date,1933/05/11
 info,site,NYC15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -2081,7 +2081,7 @@ info,hometeam,BRO
 info,date,1933/05/12
 info,site,NYC15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -2219,7 +2219,7 @@ info,hometeam,BRO
 info,date,1933/05/13
 info,site,NYC15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -2945,7 +2945,7 @@ info,hometeam,BRO
 info,date,1933/06/06
 info,site,NYC15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -3080,7 +3080,7 @@ info,hometeam,BRO
 info,date,1933/06/10
 info,site,NYC15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -3608,7 +3608,7 @@ info,hometeam,BRO
 info,date,1933/06/19
 info,site,NYC15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -3768,7 +3768,7 @@ info,hometeam,BRO
 info,date,1933/06/20
 info,site,NYC15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -3920,7 +3920,7 @@ info,hometeam,BRO
 info,date,1933/06/21
 info,site,NYC15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -4090,7 +4090,7 @@ info,hometeam,BRO
 info,date,1933/06/22
 info,site,NYC15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -4239,7 +4239,7 @@ info,hometeam,BRO
 info,date,1933/06/23
 info,site,NYC15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -4381,7 +4381,7 @@ info,hometeam,BRO
 info,date,1933/06/24
 info,site,NYC15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -4804,7 +4804,7 @@ info,hometeam,BRO
 info,date,1933/06/27
 info,site,NYC15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -5102,7 +5102,7 @@ info,hometeam,BRO
 info,date,1933/06/28
 info,site,NYC15
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98,365"
@@ -5251,7 +5251,7 @@ info,hometeam,BRO
 info,date,1933/06/29
 info,site,NYC15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -5382,7 +5382,7 @@ info,hometeam,BRO
 info,date,1933/06/30
 info,site,NYC15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -5516,7 +5516,7 @@ info,hometeam,BRO
 info,date,1933/07/01
 info,site,NYC15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -6700,7 +6700,7 @@ info,hometeam,BRO
 info,date,1933/08/08
 info,site,NYC15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -6838,7 +6838,7 @@ info,hometeam,BRO
 info,date,1933/08/12
 info,site,NYC15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -7265,7 +7265,7 @@ info,hometeam,BRO
 info,date,1933/08/16
 info,site,NYC15
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -7398,7 +7398,7 @@ info,hometeam,BRO
 info,date,1933/08/16
 info,site,NYC15
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -7551,7 +7551,7 @@ info,hometeam,BRO
 info,date,1933/08/19
 info,site,NYC15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -7986,7 +7986,7 @@ info,hometeam,BRO
 info,date,1933/08/24
 info,site,NYC15
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -8118,7 +8118,7 @@ info,hometeam,BRO
 info,date,1933/08/24
 info,site,NYC15
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98.366"
@@ -8251,7 +8251,7 @@ info,hometeam,BRO
 info,date,1933/08/25
 info,site,NYC15
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -8370,7 +8370,7 @@ info,hometeam,BRO
 info,date,1933/08/25
 info,site,NYC15
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -8500,7 +8500,7 @@ info,hometeam,BRO
 info,date,1933/08/26
 info,site,NYC15
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -8657,7 +8657,7 @@ info,hometeam,BRO
 info,date,1933/08/26
 info,site,NYC15
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -9071,7 +9071,7 @@ info,hometeam,BRO
 info,date,1933/08/29
 info,site,NYC15
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -9229,7 +9229,7 @@ info,hometeam,BRO
 info,date,1933/08/29
 info,site,NYC15
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -9363,7 +9363,7 @@ info,hometeam,BRO
 info,date,1933/08/30
 info,site,NYC15
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -9497,7 +9497,7 @@ info,hometeam,BRO
 info,date,1933/08/30
 info,site,NYC15
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -9645,7 +9645,7 @@ info,hometeam,BRO
 info,date,1933/08/31
 info,site,NYC15
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -9802,7 +9802,7 @@ info,hometeam,BRO
 info,date,1933/08/31
 info,site,NYC15
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98,366"
@@ -9949,7 +9949,7 @@ info,hometeam,BRO
 info,date,1933/09/02
 info,site,NYC15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -10782,7 +10782,7 @@ info,hometeam,BRO
 info,date,1933/09/28
 info,site,NYC15
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -10923,7 +10923,7 @@ info,hometeam,BRO
 info,date,1933/09/29
 info,site,NYC15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"

--- a/event/regular/1933BSN.EVN
+++ b/event/regular/1933BSN.EVN
@@ -5,7 +5,7 @@ info,hometeam,BSN
 info,date,1933/04/19
 info,site,BOS08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -572,7 +572,7 @@ info,hometeam,BSN
 info,date,1933/05/03
 info,site,BOS08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -1157,7 +1157,7 @@ info,hometeam,BSN
 info,date,1933/05/09
 info,site,BOS08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -1836,7 +1836,7 @@ info,hometeam,BSN
 info,date,1933/06/02
 info,site,BOS08
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98,365"
@@ -2111,7 +2111,7 @@ info,hometeam,BSN
 info,date,1933/06/03
 info,site,BOS08
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -2255,7 +2255,7 @@ info,hometeam,BSN
 info,date,1933/06/07
 info,site,BOS08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -2388,7 +2388,7 @@ info,hometeam,BSN
 info,date,1933/06/18
 info,site,BOS08
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"286"
@@ -2797,7 +2797,7 @@ info,hometeam,BSN
 info,date,1933/06/21
 info,site,BOS08
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"286"
@@ -3624,7 +3624,7 @@ info,hometeam,BSN
 info,date,1933/06/28
 info,site,BOS08
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"115"
@@ -4456,7 +4456,7 @@ info,hometeam,BSN
 info,date,1933/07/03
 info,site,BOS08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -4746,7 +4746,7 @@ info,hometeam,BSN
 info,date,1933/08/02
 info,site,BOS08
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -4881,7 +4881,7 @@ info,hometeam,BSN
 info,date,1933/08/03
 info,site,BOS08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -4999,7 +4999,7 @@ info,hometeam,BSN
 info,date,1933/08/04
 info,site,BOS08
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -5129,7 +5129,7 @@ info,hometeam,BSN
 info,date,1933/08/04
 info,site,BOS08
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -5250,7 +5250,7 @@ info,hometeam,BSN
 info,date,1933/08/05
 info,site,BOS08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -5641,7 +5641,7 @@ info,hometeam,BSN
 info,date,1933/08/18
 info,site,BOS08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -6081,7 +6081,7 @@ info,hometeam,BSN
 info,date,1933/08/22
 info,site,BOS08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -6365,7 +6365,7 @@ info,hometeam,BSN
 info,date,1933/08/24
 info,site,BOS08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -6902,7 +6902,7 @@ info,hometeam,BSN
 info,date,1933/08/28
 info,site,BOS08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -7143,7 +7143,7 @@ info,hometeam,BSN
 info,date,1933/08/31
 info,site,BOS08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -7285,7 +7285,7 @@ info,hometeam,BSN
 info,date,1933/09/01
 info,site,BOS08
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -7428,7 +7428,7 @@ info,hometeam,BSN
 info,date,1933/09/01
 info,site,BOS08
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -7562,7 +7562,7 @@ info,hometeam,BSN
 info,date,1933/09/02
 info,site,BOS08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"

--- a/event/regular/1933CHA.EVA
+++ b/event/regular/1933CHA.EVA
@@ -1280,7 +1280,7 @@ info,hometeam,CHA
 info,date,1933/05/08
 info,site,CHI10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hildg101
@@ -1419,7 +1419,7 @@ info,hometeam,CHA
 info,date,1933/05/10
 info,site,CHI10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,kolll901
@@ -2950,7 +2950,7 @@ info,hometeam,CHA
 info,date,1933/06/17
 info,site,CHI10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,owenb901
@@ -3417,7 +3417,7 @@ info,hometeam,CHA
 info,date,1933/06/19
 info,site,CHI10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,owenb901
@@ -6911,7 +6911,7 @@ info,hometeam,CHA
 info,date,1933/08/19
 info,site,CHI10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,geish901
@@ -7103,7 +7103,7 @@ info,hometeam,CHA
 info,date,1933/08/20
 info,site,CHI10
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"276"
@@ -7264,7 +7264,7 @@ info,hometeam,CHA
 info,date,1933/08/21
 info,site,CHI10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,geish901
@@ -7740,7 +7740,7 @@ info,hometeam,CHA
 info,date,1933/08/23
 info,site,CHI10
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"277"

--- a/event/regular/1933CHN.EVN
+++ b/event/regular/1933CHN.EVN
@@ -818,7 +818,7 @@ info,hometeam,CHN
 info,date,1933/05/16
 info,site,CHI11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98,277"
@@ -956,7 +956,7 @@ info,hometeam,CHN
 info,date,1933/05/18
 info,site,CHI11
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -1234,7 +1234,7 @@ info,hometeam,CHN
 info,date,1933/05/20
 info,site,CHI11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98,365"
@@ -2394,7 +2394,7 @@ info,hometeam,CHN
 info,date,1933/06/01
 info,site,CHI11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98,288"
@@ -2689,7 +2689,7 @@ info,hometeam,CHN
 info,date,1933/06/04
 info,site,CHI11
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"286"
@@ -3422,7 +3422,7 @@ info,hometeam,CHN
 info,date,1933/06/16
 info,site,CHI11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98,277"
@@ -3984,7 +3984,7 @@ info,hometeam,CHN
 info,date,1933/07/07
 info,site,CHI11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98,277"
@@ -4170,7 +4170,7 @@ info,hometeam,CHN
 info,date,1933/07/08
 info,site,CHI11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -4428,7 +4428,7 @@ info,hometeam,CHN
 info,date,1933/07/11
 info,site,CHI11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -4561,7 +4561,7 @@ info,hometeam,CHN
 info,date,1933/07/12
 info,site,CHI11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98,366"
@@ -4688,7 +4688,7 @@ info,hometeam,CHN
 info,date,1933/07/13
 info,site,CHI11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98,365"
@@ -4822,7 +4822,7 @@ info,hometeam,CHN
 info,date,1933/07/14
 info,site,CHI11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98,365"
@@ -5113,7 +5113,7 @@ info,hometeam,CHN
 info,date,1933/07/16
 info,site,CHI11
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"276"
@@ -6771,7 +6771,7 @@ info,hometeam,CHN
 info,date,1933/09/04
 info,site,CHI11
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"209"
@@ -7719,7 +7719,7 @@ info,hometeam,CHN
 info,date,1933/09/14
 info,site,CHI11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -7853,7 +7853,7 @@ info,hometeam,CHN
 info,date,1933/09/15
 info,site,CHI11
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -8000,7 +8000,7 @@ info,hometeam,CHN
 info,date,1933/09/16
 info,site,CHI11
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -8129,7 +8129,7 @@ info,hometeam,CHN
 info,date,1933/09/16
 info,site,CHI11
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98,277"
@@ -8557,7 +8557,7 @@ info,hometeam,CHN
 info,date,1933/09/18
 info,site,CHI11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98,366"
@@ -8704,7 +8704,7 @@ info,hometeam,CHN
 info,date,1933/09/19
 info,site,CHI11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"

--- a/event/regular/1933CIN.EVN
+++ b/event/regular/1933CIN.EVN
@@ -2038,7 +2038,7 @@ info,hometeam,CIN
 info,date,1933/05/22
 info,site,CIN07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -2167,7 +2167,7 @@ info,hometeam,CIN
 info,date,1933/05/23
 info,site,CIN07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98,508"
@@ -2300,7 +2300,7 @@ info,hometeam,CIN
 info,date,1933/05/24
 info,site,CIN07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -2437,7 +2437,7 @@ info,hometeam,CIN
 info,date,1933/05/25
 info,site,CIN07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -2569,7 +2569,7 @@ info,hometeam,CIN
 info,date,1933/05/26
 info,site,CIN07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -2690,7 +2690,7 @@ info,hometeam,CIN
 info,date,1933/05/27
 info,site,CIN07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98,365"
@@ -3854,7 +3854,7 @@ info,hometeam,CIN
 info,date,1933/06/12
 info,site,CIN07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -6187,7 +6187,7 @@ info,hometeam,CIN
 info,date,1933/07/18
 info,site,CIN07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -6342,7 +6342,7 @@ info,hometeam,CIN
 info,date,1933/07/19
 info,site,CIN07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -6498,7 +6498,7 @@ info,hometeam,CIN
 info,date,1933/07/20
 info,site,CIN07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -6626,7 +6626,7 @@ info,hometeam,CIN
 info,date,1933/07/21
 info,site,CIN07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -6753,7 +6753,7 @@ info,hometeam,CIN
 info,date,1933/07/22
 info,site,CIN07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -6893,7 +6893,7 @@ info,hometeam,CIN
 info,date,1933/07/23
 info,site,CIN07
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"286"
@@ -7165,7 +7165,7 @@ info,hometeam,CIN
 info,date,1933/07/30
 info,site,CIN07
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"286"
@@ -7469,7 +7469,7 @@ info,hometeam,CIN
 info,date,1933/08/05
 info,site,CIN07
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"412"
@@ -8429,7 +8429,7 @@ info,hometeam,CIN
 info,date,1933/09/06
 info,site,CIN07
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -8751,7 +8751,7 @@ info,hometeam,CIN
 info,date,1933/09/07
 info,site,CIN07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -8885,7 +8885,7 @@ info,hometeam,CIN
 info,date,1933/09/08
 info,site,CIN07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -9026,7 +9026,7 @@ info,hometeam,CIN
 info,date,1933/09/09
 info,site,CIN07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98,507"
@@ -9477,7 +9477,7 @@ info,hometeam,CIN
 info,date,1933/09/11
 info,site,CIN07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98,507"

--- a/event/regular/1933CLE.EVA
+++ b/event/regular/1933CLE.EVA
@@ -1019,7 +1019,7 @@ info,hometeam,CLE
 info,date,1933/05/01
 info,site,CLE07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mcgob901
@@ -1298,7 +1298,7 @@ info,hometeam,CLE
 info,date,1933/05/06
 info,site,CLE07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,owenb901
@@ -5891,7 +5891,7 @@ info,hometeam,CLE
 info,date,1933/07/01
 info,site,CLE07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,morig101
@@ -6032,7 +6032,7 @@ info,hometeam,CLE
 info,date,1933/07/03
 info,site,CLE07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,owenb901
@@ -6321,7 +6321,7 @@ info,hometeam,CLE
 info,date,1933/07/28
 info,site,CLE07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,kolll901

--- a/event/regular/1933DET.EVA
+++ b/event/regular/1933DET.EVA
@@ -872,7 +872,7 @@ info,hometeam,DET
 info,date,1933/05/02
 info,site,DET04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,geish901
@@ -1287,7 +1287,7 @@ info,hometeam,DET
 info,date,1933/05/30
 info,site,DET04
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,morig101
@@ -2867,7 +2867,7 @@ info,hometeam,DET
 info,date,1933/06/27
 info,site,DET04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,vangr901
@@ -3040,7 +3040,7 @@ info,hometeam,DET
 info,date,1933/06/28
 info,site,DET04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,summb901
@@ -5540,7 +5540,7 @@ info,hometeam,DET
 info,date,1933/08/26
 info,site,DET04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,ormsr901
@@ -5692,7 +5692,7 @@ info,hometeam,DET
 info,date,1933/08/27
 info,site,DET04
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"209"
@@ -6003,7 +6003,7 @@ info,hometeam,DET
 info,date,1933/08/28
 info,site,DET04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,owenb901
@@ -6135,7 +6135,7 @@ info,hometeam,DET
 info,date,1933/08/29
 info,site,DET04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,ormsr901

--- a/event/regular/1933NY1.EVN
+++ b/event/regular/1933NY1.EVN
@@ -5,7 +5,7 @@ info,hometeam,NY1
 info,date,1933/04/20
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -124,7 +124,7 @@ info,hometeam,NY1
 info,date,1933/04/21
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -271,7 +271,7 @@ info,hometeam,NY1
 info,date,1933/04/22
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -429,7 +429,7 @@ info,hometeam,NY1
 info,date,1933/04/24
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -570,7 +570,7 @@ info,hometeam,NY1
 info,date,1933/04/25
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -714,7 +714,7 @@ info,hometeam,NY1
 info,date,1933/04/26
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -831,7 +831,7 @@ info,hometeam,NY1
 info,date,1933/04/27
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -973,7 +973,7 @@ info,hometeam,NY1
 info,date,1933/05/02
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -1249,7 +1249,7 @@ info,hometeam,NY1
 info,date,1933/05/04
 info,site,NYC14
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98,277"
@@ -1389,7 +1389,7 @@ info,hometeam,NY1
 info,date,1933/05/05
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -1782,7 +1782,7 @@ info,hometeam,NY1
 info,date,1933/05/08
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -1920,7 +1920,7 @@ info,hometeam,NY1
 info,date,1933/05/11
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -2076,7 +2076,7 @@ info,hometeam,NY1
 info,date,1933/05/12
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -2220,7 +2220,7 @@ info,hometeam,NY1
 info,date,1933/05/13
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -2772,7 +2772,7 @@ info,hometeam,NY1
 info,date,1933/06/08
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -2921,7 +2921,7 @@ info,hometeam,NY1
 info,date,1933/06/10
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -3057,7 +3057,7 @@ info,hometeam,NY1
 info,date,1933/06/13
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -3198,7 +3198,7 @@ info,hometeam,NY1
 info,date,1933/06/14
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -3333,7 +3333,7 @@ info,hometeam,NY1
 info,date,1933/06/15
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -3485,7 +3485,7 @@ info,hometeam,NY1
 info,date,1933/06/16
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -3623,7 +3623,7 @@ info,hometeam,NY1
 info,date,1933/06/17
 info,site,NYC14
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -3951,7 +3951,7 @@ info,hometeam,NY1
 info,date,1933/06/19
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -4077,7 +4077,7 @@ info,hometeam,NY1
 info,date,1933/06/20
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -4230,7 +4230,7 @@ info,hometeam,NY1
 info,date,1933/06/21
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -4347,7 +4347,7 @@ info,hometeam,NY1
 info,date,1933/06/22
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -4465,7 +4465,7 @@ info,hometeam,NY1
 info,date,1933/06/23
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -4596,7 +4596,7 @@ info,hometeam,NY1
 info,date,1933/06/24
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -5009,7 +5009,7 @@ info,hometeam,NY1
 info,date,1933/06/28
 info,site,NYC14
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"286"
@@ -5147,7 +5147,7 @@ info,hometeam,NY1
 info,date,1933/06/28
 info,site,NYC14
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -5299,7 +5299,7 @@ info,hometeam,NY1
 info,date,1933/06/29
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -5435,7 +5435,7 @@ info,hometeam,NY1
 info,date,1933/06/30
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -5561,7 +5561,7 @@ info,hometeam,NY1
 info,date,1933/07/01
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -5712,7 +5712,7 @@ info,hometeam,NY1
 info,date,1933/07/26
 info,site,NYC14
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -5847,7 +5847,7 @@ info,hometeam,NY1
 info,date,1933/07/26
 info,site,NYC14
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -5982,7 +5982,7 @@ info,hometeam,NY1
 info,date,1933/07/27
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -6107,7 +6107,7 @@ info,hometeam,NY1
 info,date,1933/07/29
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -6266,7 +6266,7 @@ info,hometeam,NY1
 info,date,1933/08/01
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -6411,7 +6411,7 @@ info,hometeam,NY1
 info,date,1933/08/10
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -6538,7 +6538,7 @@ info,hometeam,NY1
 info,date,1933/08/12
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -6674,7 +6674,7 @@ info,hometeam,NY1
 info,date,1933/08/16
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -6799,7 +6799,7 @@ info,hometeam,NY1
 info,date,1933/08/17
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -6942,7 +6942,7 @@ info,hometeam,NY1
 info,date,1933/08/18
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -7076,7 +7076,7 @@ info,hometeam,NY1
 info,date,1933/08/19
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -7224,7 +7224,7 @@ info,hometeam,NY1
 info,date,1933/08/25
 info,site,NYC14
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -7520,7 +7520,7 @@ info,hometeam,NY1
 info,date,1933/08/26
 info,site,NYC14
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -7643,7 +7643,7 @@ info,hometeam,NY1
 info,date,1933/08/26
 info,site,NYC14
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -7793,7 +7793,7 @@ info,hometeam,NY1
 info,date,1933/08/28
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -7960,7 +7960,7 @@ info,hometeam,NY1
 info,date,1933/08/29
 info,site,NYC14
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -8087,7 +8087,7 @@ info,hometeam,NY1
 info,date,1933/08/29
 info,site,NYC14
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -8214,7 +8214,7 @@ info,hometeam,NY1
 info,date,1933/08/30
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -8357,7 +8357,7 @@ info,hometeam,NY1
 info,date,1933/09/23
 info,site,NYC14
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -8515,7 +8515,7 @@ info,hometeam,NY1
 info,date,1933/09/23
 info,site,NYC14
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -8642,7 +8642,7 @@ info,hometeam,NY1
 info,date,1933/09/26
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -8764,7 +8764,7 @@ info,hometeam,NY1
 info,date,1933/09/27
 info,site,NYC14
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"

--- a/event/regular/1933NYA.EVA
+++ b/event/regular/1933NYA.EVA
@@ -5,7 +5,7 @@ info,hometeam,NYA
 info,date,1933/04/13
 info,site,NYC16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,morig101
@@ -149,7 +149,7 @@ info,hometeam,NYA
 info,date,1933/04/14
 info,site,NYC16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,geish901
@@ -275,7 +275,7 @@ info,hometeam,NYA
 info,date,1933/04/15
 info,site,NYC16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,morig101
@@ -572,7 +572,7 @@ info,hometeam,NYA
 info,date,1933/04/18
 info,site,NYC16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,morig101
@@ -686,7 +686,7 @@ info,hometeam,NYA
 info,date,1933/04/28
 info,site,NYC16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dinnb101
@@ -827,7 +827,7 @@ info,hometeam,NYA
 info,date,1933/04/29
 info,site,NYC16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hildg101
@@ -969,7 +969,7 @@ info,hometeam,NYA
 info,date,1933/05/17
 info,site,NYC16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,ormsr901
@@ -1100,7 +1100,7 @@ info,hometeam,NYA
 info,date,1933/05/18
 info,site,NYC16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,summb901
@@ -1229,7 +1229,7 @@ info,hometeam,NYA
 info,date,1933/05/19
 info,site,NYC16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mcgob901
@@ -1366,7 +1366,7 @@ info,hometeam,NYA
 info,date,1933/05/20
 info,site,NYC16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,ormsr901
@@ -1494,7 +1494,7 @@ info,hometeam,NYA
 info,date,1933/05/22
 info,site,NYC16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,morig101
@@ -1623,7 +1623,7 @@ info,hometeam,NYA
 info,date,1933/05/23
 info,site,NYC16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,geish901
@@ -1763,7 +1763,7 @@ info,hometeam,NYA
 info,date,1933/05/26
 info,site,NYC16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,morig101
@@ -1913,7 +1913,7 @@ info,hometeam,NYA
 info,date,1933/05/27
 info,site,NYC16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,geish901
@@ -2087,7 +2087,7 @@ info,hometeam,NYA
 info,date,1933/06/02
 info,site,NYC16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,owenb901
@@ -2233,7 +2233,7 @@ info,hometeam,NYA
 info,date,1933/06/03
 info,site,NYC16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,vangr901
@@ -2669,7 +2669,7 @@ info,hometeam,NYA
 info,date,1933/06/06
 info,site,NYC16
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,owenb901
@@ -2795,7 +2795,7 @@ info,hometeam,NYA
 info,date,1933/06/06
 info,site,NYC16
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,vangr901
@@ -2932,7 +2932,7 @@ info,hometeam,NYA
 info,date,1933/07/07
 info,site,NYC16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,kolll901
@@ -3085,7 +3085,7 @@ info,hometeam,NYA
 info,date,1933/07/08
 info,site,NYC16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dinnb101
@@ -3233,7 +3233,7 @@ info,hometeam,NYA
 info,date,1933/07/10
 info,site,NYC16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dinnb101
@@ -3393,7 +3393,7 @@ info,hometeam,NYA
 info,date,1933/07/11
 info,site,NYC16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mcgob901
@@ -3552,7 +3552,7 @@ info,hometeam,NYA
 info,date,1933/07/12
 info,site,NYC16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,kolll901
@@ -3691,7 +3691,7 @@ info,hometeam,NYA
 info,date,1933/07/13
 info,site,NYC16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dinnb101
@@ -3831,7 +3831,7 @@ info,hometeam,NYA
 info,date,1933/07/14
 info,site,NYC16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mcgob901
@@ -3984,7 +3984,7 @@ info,hometeam,NYA
 info,date,1933/07/15
 info,site,NYC16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,owenb901
@@ -4115,7 +4115,7 @@ info,hometeam,NYA
 info,date,1933/07/18
 info,site,NYC16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,vangr901
@@ -4265,7 +4265,7 @@ info,hometeam,NYA
 info,date,1933/07/19
 info,site,NYC16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,owenb901
@@ -4414,7 +4414,7 @@ info,hometeam,NYA
 info,date,1933/07/20
 info,site,NYC16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,vangr901
@@ -4545,7 +4545,7 @@ info,hometeam,NYA
 info,date,1933/07/21
 info,site,NYC16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,owenb901
@@ -4693,7 +4693,7 @@ info,hometeam,NYA
 info,date,1933/07/22
 info,site,NYC16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,vangr901
@@ -4823,7 +4823,7 @@ info,hometeam,NYA
 info,date,1933/08/02
 info,site,NYC16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,geish901
@@ -4996,7 +4996,7 @@ info,hometeam,NYA
 info,date,1933/08/03
 info,site,NYC16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,ormsr901
@@ -5140,7 +5140,7 @@ info,hometeam,NYA
 info,date,1933/08/05
 info,site,NYC16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,morig101
@@ -5430,7 +5430,7 @@ info,hometeam,NYA
 info,date,1933/08/07
 info,site,NYC16
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,ormsr901
@@ -5581,7 +5581,7 @@ info,hometeam,NYA
 info,date,1933/08/07
 info,site,NYC16
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,summb901
@@ -5733,7 +5733,7 @@ info,hometeam,NYA
 info,date,1933/08/08
 info,site,NYC16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mcgob901
@@ -5861,7 +5861,7 @@ info,hometeam,NYA
 info,date,1933/08/09
 info,site,NYC16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,ormsr901
@@ -5989,7 +5989,7 @@ info,hometeam,NYA
 info,date,1933/08/31
 info,site,NYC16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,owenb901
@@ -6139,7 +6139,7 @@ info,hometeam,NYA
 info,date,1933/09/01
 info,site,NYC16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,vangr901
@@ -6317,7 +6317,7 @@ info,hometeam,NYA
 info,date,1933/09/02
 info,site,NYC16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,owenb901
@@ -6453,7 +6453,7 @@ info,hometeam,NYA
 info,date,1933/09/06
 info,site,NYC16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,vangr901
@@ -6585,7 +6585,7 @@ info,hometeam,NYA
 info,date,1933/09/07
 info,site,NYC16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,owenb901
@@ -6750,7 +6750,7 @@ info,hometeam,NYA
 info,date,1933/09/08
 info,site,NYC16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,vangr901
@@ -6892,7 +6892,7 @@ info,hometeam,NYA
 info,date,1933/09/09
 info,site,NYC16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,owenb901
@@ -7039,7 +7039,7 @@ info,hometeam,NYA
 info,date,1933/09/11
 info,site,NYC16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,vangr901
@@ -7162,7 +7162,7 @@ info,hometeam,NYA
 info,date,1933/09/12
 info,site,NYC16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,owenb901
@@ -7554,7 +7554,7 @@ info,hometeam,NYA
 info,date,1933/09/18
 info,site,NYC16
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mcgob901
@@ -7683,7 +7683,7 @@ info,hometeam,NYA
 info,date,1933/09/18
 info,site,NYC16
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,summb901
@@ -7826,7 +7826,7 @@ info,hometeam,NYA
 info,date,1933/09/19
 info,site,NYC16
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mcgob901
@@ -7961,7 +7961,7 @@ info,hometeam,NYA
 info,date,1933/09/19
 info,site,NYC16
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,summb901
@@ -8122,7 +8122,7 @@ info,hometeam,NYA
 info,date,1933/09/20
 info,site,NYC16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mcgob901
@@ -8260,7 +8260,7 @@ info,hometeam,NYA
 info,date,1933/09/28
 info,site,NYC16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dinnb101
@@ -8431,7 +8431,7 @@ info,hometeam,NYA
 info,date,1933/09/29
 info,site,NYC16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,summb901

--- a/event/regular/1933PHA.EVA
+++ b/event/regular/1933PHA.EVA
@@ -445,7 +445,7 @@ info,hometeam,PHA
 info,date,1933/04/27
 info,site,PHI11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,geish901
@@ -882,7 +882,7 @@ info,hometeam,PHA
 info,date,1933/05/15
 info,site,PHI11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,geish901
@@ -1878,7 +1878,7 @@ info,hometeam,PHA
 info,date,1933/05/24
 info,site,PHI11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,vangr901
@@ -2004,7 +2004,7 @@ info,hometeam,PHA
 info,date,1933/05/25
 info,site,PHI11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,owenb901
@@ -2452,7 +2452,7 @@ info,hometeam,PHA
 info,date,1933/06/05
 info,site,PHI11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mcgob901
@@ -2746,7 +2746,7 @@ info,hometeam,PHA
 info,date,1933/06/07
 info,site,PHI11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mcgob901
@@ -2926,7 +2926,7 @@ info,hometeam,PHA
 info,date,1933/06/08
 info,site,PHI11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,summb901
@@ -3081,7 +3081,7 @@ info,hometeam,PHA
 info,date,1933/06/09
 info,site,PHI11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mcgob901
@@ -3244,7 +3244,7 @@ info,hometeam,PHA
 info,date,1933/06/10
 info,site,PHI11
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,summb901
@@ -3384,7 +3384,7 @@ info,hometeam,PHA
 info,date,1933/06/10
 info,site,PHI11
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,summb901
@@ -3830,7 +3830,7 @@ info,hometeam,PHA
 info,date,1933/07/05
 info,site,PHI11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,morig101
@@ -4581,7 +4581,7 @@ info,hometeam,PHA
 info,date,1933/07/10
 info,site,PHI11
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,ormsr901
@@ -6477,7 +6477,7 @@ info,hometeam,PHA
 info,date,1933/07/24
 info,site,PHI11
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,morig101
@@ -6606,7 +6606,7 @@ info,hometeam,PHA
 info,date,1933/07/24
 info,site,PHI11
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,ormsr901
@@ -6766,7 +6766,7 @@ info,hometeam,PHA
 info,date,1933/07/25
 info,site,PHI11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,geish901
@@ -7337,7 +7337,7 @@ info,hometeam,PHA
 info,date,1933/08/12
 info,site,PHI11
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,geish901
@@ -7519,7 +7519,7 @@ info,hometeam,PHA
 info,date,1933/08/12
 info,site,PHI11
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,morig101
@@ -8121,7 +8121,7 @@ info,hometeam,PHA
 info,date,1933/09/05
 info,site,PHI11
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,vangr901
@@ -8254,7 +8254,7 @@ info,hometeam,PHA
 info,date,1933/09/05
 info,site,PHI11
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,owenb901
@@ -8974,7 +8974,7 @@ info,hometeam,PHA
 info,date,1933/09/11
 info,site,PHI11
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"277"
@@ -10233,7 +10233,7 @@ info,hometeam,PHA
 info,date,1933/09/21
 info,site,PHI11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,owenb901
@@ -10527,7 +10527,7 @@ info,hometeam,PHA
 info,date,1933/09/27
 info,site,PHI11
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,ormsr901

--- a/event/regular/1933PHI.EVN
+++ b/event/regular/1933PHI.EVN
@@ -5,7 +5,7 @@ info,hometeam,PHI
 info,date,1933/04/13
 info,site,PHI09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -148,7 +148,7 @@ info,hometeam,PHI
 info,date,1933/04/14
 info,site,PHI09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -296,7 +296,7 @@ info,hometeam,PHI
 info,date,1933/04/15
 info,site,PHI09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -421,7 +421,7 @@ info,hometeam,PHI
 info,date,1933/04/18
 info,site,PHI09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -887,7 +887,7 @@ info,hometeam,PHI
 info,date,1933/05/01
 info,site,PHI09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98,341"
@@ -1611,7 +1611,7 @@ info,hometeam,PHI
 info,date,1933/05/10
 info,site,PHI09
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -2201,7 +2201,7 @@ info,hometeam,PHI
 info,date,1933/06/01
 info,site,PHI09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -2349,7 +2349,7 @@ info,hometeam,PHI
 info,date,1933/06/02
 info,site,PHI09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -2513,7 +2513,7 @@ info,hometeam,PHI
 info,date,1933/06/03
 info,site,PHI09
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -2646,7 +2646,7 @@ info,hometeam,PHI
 info,date,1933/06/12
 info,site,PHI09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -2793,7 +2793,7 @@ info,hometeam,PHI
 info,date,1933/06/13
 info,site,PHI09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -2949,7 +2949,7 @@ info,hometeam,PHI
 info,date,1933/06/14
 info,site,PHI09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -3101,7 +3101,7 @@ info,hometeam,PHI
 info,date,1933/06/15
 info,site,PHI09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98,365"
@@ -5922,7 +5922,7 @@ info,hometeam,PHI
 info,date,1933/07/28
 info,site,PHI09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98,341"
@@ -6097,7 +6097,7 @@ info,hometeam,PHI
 info,date,1933/07/29
 info,site,PHI09
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -6275,7 +6275,7 @@ info,hometeam,PHI
 info,date,1933/07/29
 info,site,PHI09
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98,341"
@@ -6435,7 +6435,7 @@ info,hometeam,PHI
 info,date,1933/08/02
 info,site,PHI09
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -6609,7 +6609,7 @@ info,hometeam,PHI
 info,date,1933/08/02
 info,site,PHI09
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98,341"
@@ -6760,7 +6760,7 @@ info,hometeam,PHI
 info,date,1933/08/04
 info,site,PHI09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -6914,7 +6914,7 @@ info,hometeam,PHI
 info,date,1933/08/05
 info,site,PHI09
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -7064,7 +7064,7 @@ info,hometeam,PHI
 info,date,1933/08/05
 info,site,PHI09
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98,341"
@@ -7640,7 +7640,7 @@ info,hometeam,PHI
 info,date,1933/08/17
 info,site,PHI09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -8052,7 +8052,7 @@ info,hometeam,PHI
 info,date,1933/08/24
 info,site,PHI09
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"277"
@@ -9534,7 +9534,7 @@ info,hometeam,PHI
 info,date,1933/09/22
 info,site,PHI09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -9662,7 +9662,7 @@ info,hometeam,PHI
 info,date,1933/09/25
 info,site,PHI09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -9807,7 +9807,7 @@ info,hometeam,PHI
 info,date,1933/09/26
 info,site,PHI09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"

--- a/event/regular/1933PIT.EVN
+++ b/event/regular/1933PIT.EVN
@@ -407,7 +407,7 @@ info,hometeam,PIT
 info,date,1933/04/28
 info,site,PIT06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -661,7 +661,7 @@ info,hometeam,PIT
 info,date,1933/05/15
 info,site,PIT06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -939,7 +939,7 @@ info,hometeam,PIT
 info,date,1933/05/17
 info,site,PIT06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -1224,7 +1224,7 @@ info,hometeam,PIT
 info,date,1933/05/19
 info,site,PIT06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -1371,7 +1371,7 @@ info,hometeam,PIT
 info,date,1933/05/20
 info,site,PIT06
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"115"
@@ -1506,7 +1506,7 @@ info,hometeam,PIT
 info,date,1933/05/22
 info,site,PIT06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -1635,7 +1635,7 @@ info,hometeam,PIT
 info,date,1933/05/23
 info,site,PIT06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -1759,7 +1759,7 @@ info,hometeam,PIT
 info,date,1933/05/24
 info,site,PIT06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -1919,7 +1919,7 @@ info,hometeam,PIT
 info,date,1933/05/26
 info,site,PIT06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -2335,7 +2335,7 @@ info,hometeam,PIT
 info,date,1933/05/31
 info,site,PIT06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -3345,7 +3345,7 @@ info,hometeam,PIT
 info,date,1933/07/04
 info,site,PIT06
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"286"
@@ -3606,7 +3606,7 @@ info,hometeam,PIT
 info,date,1933/07/05
 info,site,PIT06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -4488,7 +4488,7 @@ info,hometeam,PIT
 info,date,1933/07/17
 info,site,PIT06
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -4639,7 +4639,7 @@ info,hometeam,PIT
 info,date,1933/07/17
 info,site,PIT06
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -4776,7 +4776,7 @@ info,hometeam,PIT
 info,date,1933/07/18
 info,site,PIT06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -4943,7 +4943,7 @@ info,hometeam,PIT
 info,date,1933/07/19
 info,site,PIT06
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -5075,7 +5075,7 @@ info,hometeam,PIT
 info,date,1933/07/19
 info,site,PIT06
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98,276"
@@ -5234,7 +5234,7 @@ info,hometeam,PIT
 info,date,1933/07/20
 info,site,PIT06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -5373,7 +5373,7 @@ info,hometeam,PIT
 info,date,1933/07/21
 info,site,PIT06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -5529,7 +5529,7 @@ info,hometeam,PIT
 info,date,1933/07/22
 info,site,PIT06
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -5656,7 +5656,7 @@ info,hometeam,PIT
 info,date,1933/07/25
 info,site,PIT06
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -5806,7 +5806,7 @@ info,hometeam,PIT
 info,date,1933/07/25
 info,site,PIT06
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98,277"
@@ -6377,7 +6377,7 @@ info,hometeam,PIT
 info,date,1933/08/01
 info,site,PIT06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -7120,7 +7120,7 @@ info,hometeam,PIT
 info,date,1933/08/12
 info,site,PIT06
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"277"
@@ -7783,7 +7783,7 @@ info,hometeam,PIT
 info,date,1933/09/05
 info,site,PIT06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -7931,7 +7931,7 @@ info,hometeam,PIT
 info,date,1933/09/06
 info,site,PIT06
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -8242,7 +8242,7 @@ info,hometeam,PIT
 info,date,1933/09/07
 info,site,PIT06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -8402,7 +8402,7 @@ info,hometeam,PIT
 info,date,1933/09/08
 info,site,PIT06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -8538,7 +8538,7 @@ info,hometeam,PIT
 info,date,1933/09/09
 info,site,PIT06
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -8973,7 +8973,7 @@ info,hometeam,PIT
 info,date,1933/09/12
 info,site,PIT06
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"
@@ -9241,7 +9241,7 @@ info,hometeam,PIT
 info,date,1933/09/16
 info,site,PIT06
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"115"
@@ -9388,7 +9388,7 @@ info,hometeam,PIT
 info,date,1933/09/18
 info,site,PIT06
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"286"
@@ -9650,7 +9650,7 @@ info,hometeam,PIT
 info,date,1933/09/19
 info,site,PIT06
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"286"
@@ -9910,7 +9910,7 @@ info,hometeam,PIT
 info,date,1933/09/20
 info,site,PIT06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98"

--- a/event/regular/1933SLA.EVA
+++ b/event/regular/1933SLA.EVA
@@ -3166,7 +3166,7 @@ info,hometeam,SLA
 info,date,1933/06/23
 info,site,STL07
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dinnb101
@@ -3755,7 +3755,7 @@ info,hometeam,SLA
 info,date,1933/06/30
 info,site,STL07
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"412"
@@ -6569,7 +6569,7 @@ info,hometeam,SLA
 info,date,1933/08/24
 info,site,STL07
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,geish901
@@ -7140,7 +7140,7 @@ info,hometeam,SLA
 info,date,1933/08/29
 info,site,STL07
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,geish901

--- a/event/regular/1933SLN.EVN
+++ b/event/regular/1933SLN.EVN
@@ -1739,7 +1739,7 @@ info,hometeam,SLN
 info,date,1933/05/30
 info,site,STL07
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"412"
@@ -2488,7 +2488,7 @@ info,hometeam,SLN
 info,date,1933/06/11
 info,site,STL07
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"286"
@@ -6465,7 +6465,7 @@ info,hometeam,SLN
 info,date,1933/09/16
 info,site,STL07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"98,366"

--- a/event/regular/1933WS1.EVA
+++ b/event/regular/1933WS1.EVA
@@ -425,7 +425,7 @@ info,hometeam,WS1
 info,date,1933/04/17
 info,site,WAS09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hildg101
@@ -575,7 +575,7 @@ info,hometeam,WS1
 info,date,1933/04/24
 info,site,WAS09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,geish901
@@ -2115,7 +2115,7 @@ info,hometeam,WS1
 info,date,1933/05/31
 info,site,WAS09
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,vangr901
@@ -3301,7 +3301,7 @@ info,hometeam,WS1
 info,date,1933/07/15
 info,site,WAS09
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,summb901
@@ -3979,7 +3979,7 @@ info,hometeam,WS1
 info,date,1933/07/27
 info,site,WAS09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,morig101
@@ -4136,7 +4136,7 @@ info,hometeam,WS1
 info,date,1933/07/29
 info,site,WAS09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,geish901
@@ -4280,7 +4280,7 @@ info,hometeam,WS1
 info,date,1933/07/31
 info,site,WAS09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,morig101
@@ -5714,7 +5714,7 @@ info,hometeam,WS1
 info,date,1933/09/21
 info,site,WAS09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dinnb101

--- a/event/regular/1934BOS.EVA
+++ b/event/regular/1934BOS.EVA
@@ -6,7 +6,7 @@ info,hometeam,BOS
 info,date,1934/04/19
 info,site,BOS07
 info,number,1
-info,starttime,0:00AM
+info,starttime,0:00PM
 info,daynight,day
 info,umphome,owenb901
 info,ump1b,mcgob901

--- a/event/regular/1934BSN.EVN
+++ b/event/regular/1934BSN.EVN
@@ -4256,7 +4256,7 @@ info,hometeam,BSN
 info,date,1934/07/25
 info,site,BOS08
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"115"

--- a/event/regular/1934CHA.EVA
+++ b/event/regular/1934CHA.EVA
@@ -2572,7 +2572,7 @@ info,hometeam,CHA
 info,date,1934/06/05
 info,site,CHI10
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,umphome,mcgob901
 info,ump1b,hildg101
@@ -6655,7 +6655,7 @@ info,hometeam,CHA
 info,date,1934/09/19
 info,site,CHI10
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,umphome,summb901
 info,ump1b,hildg101

--- a/event/regular/1934CIN.EVN
+++ b/event/regular/1934CIN.EVN
@@ -7833,7 +7833,7 @@ info,hometeam,CIN
 info,date,1934/08/07
 info,site,CIN07
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"412"

--- a/event/regular/1934CLE.EVA
+++ b/event/regular/1934CLE.EVA
@@ -7566,7 +7566,7 @@ info,hometeam,CLE
 info,date,1934/09/08
 info,site,CLE06
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,umphome,ormsr901
 info,ump1b,hildg101

--- a/event/regular/1934DET.EVA
+++ b/event/regular/1934DET.EVA
@@ -5835,7 +5835,7 @@ info,hometeam,DET
 info,date,1934/09/08
 info,site,DET04
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,umphome,geish901
 info,ump1b,owenb901
@@ -6979,7 +6979,7 @@ info,hometeam,DET
 info,date,1934/09/26
 info,site,DET04
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,umphome,summb901
 info,ump1b,donnc901

--- a/event/regular/1934NYA.EVA
+++ b/event/regular/1934NYA.EVA
@@ -4313,7 +4313,7 @@ info,hometeam,NYA
 info,date,1934/07/02
 info,site,NYC16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,umphome,owenb901
 info,ump1b,mcgob901

--- a/event/regular/1934PHA.EVA
+++ b/event/regular/1934PHA.EVA
@@ -4389,7 +4389,7 @@ info,hometeam,PHA
 info,date,1934/06/21
 info,site,PHI11
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,umphome,kolll901
 info,ump1b,donnc901
@@ -4672,7 +4672,7 @@ info,hometeam,PHA
 info,date,1934/06/23
 info,site,PHI11
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,umphome,kolll901
 info,ump1b,donnc901
@@ -8890,7 +8890,7 @@ info,hometeam,PHA
 info,date,1934/08/25
 info,site,PHI11
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,umphome,kolll901
 info,ump1b,dinnb101
@@ -9457,7 +9457,7 @@ info,hometeam,PHA
 info,date,1934/08/29
 info,site,PHI11
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,umphome,summb901
 info,ump1b,mcgob901

--- a/event/regular/1934PHI.EVN
+++ b/event/regular/1934PHI.EVN
@@ -2278,7 +2278,7 @@ info,hometeam,PHI
 info,date,1934/07/12
 info,site,PHI09
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"412"
@@ -3735,7 +3735,7 @@ info,hometeam,PHI
 info,date,1934/08/04
 info,site,PHI09
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"270"
@@ -4892,7 +4892,7 @@ info,hometeam,PHI
 info,date,1934/09/11
 info,site,PHI09
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"412"
@@ -5305,7 +5305,7 @@ info,hometeam,PHI
 info,date,1934/09/18
 info,site,PHI09
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"277"

--- a/event/regular/1934PIT.EVN
+++ b/event/regular/1934PIT.EVN
@@ -5740,7 +5740,7 @@ info,hometeam,PIT
 info,date,1934/09/03
 info,site,PIT06
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"412"

--- a/event/regular/1934SLA.EVA
+++ b/event/regular/1934SLA.EVA
@@ -2907,7 +2907,7 @@ info,hometeam,SLA
 info,date,1934/08/01
 info,site,STL07
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,umphome,summb901
 info,ump1b,mcgob901
@@ -3475,7 +3475,7 @@ info,hometeam,SLA
 info,date,1934/09/03
 info,site,STL07
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,umphome,geish901
 info,ump1b,owenb901
@@ -3915,7 +3915,7 @@ info,hometeam,SLA
 info,date,1934/09/07
 info,site,STL07
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,umphome,donnc901
 info,ump1b,mcgob901
@@ -4351,7 +4351,7 @@ info,hometeam,SLA
 info,date,1934/09/14
 info,site,STL07
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,umphome,geish901
 info,ump1b,kolll901
@@ -5031,7 +5031,7 @@ info,hometeam,SLA
 info,date,1934/09/22
 info,site,STL07
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,umphome,ormsr901
 info,ump1b,kolll901

--- a/event/regular/1934SLN.EVN
+++ b/event/regular/1934SLN.EVN
@@ -4017,7 +4017,7 @@ info,hometeam,SLN
 info,date,1934/08/16
 info,site,STL07
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"412"

--- a/event/regular/1937BSN.EVN
+++ b/event/regular/1937BSN.EVN
@@ -6,7 +6,7 @@ info,hometeam,BSN
 info,date,1937/04/19
 info,site,BOS08
 info,number,1
-info,starttime,0:00AM
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"115"

--- a/event/regular/1937CHA.EVA
+++ b/event/regular/1937CHA.EVA
@@ -762,7 +762,7 @@ info,hometeam,CHA
 info,date,1937/05/07
 info,site,CHI10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,umphome,dinnb101
 info,ump1b,owenb901

--- a/event/regular/1938WS1.EVA
+++ b/event/regular/1938WS1.EVA
@@ -5,7 +5,7 @@ info,hometeam,WS1
 info,date,1938/04/18
 info,site,WAS09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mcgob901

--- a/event/regular/1943BSN.EVN
+++ b/event/regular/1943BSN.EVN
@@ -469,7 +469,7 @@ info,hometeam,BSN
 info,date,1943/05/08
 info,site,BOS08
 info,number,0
-info,starttime,0:00AM
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,scorer,"115,347"

--- a/event/regular/1945BSN.EVN
+++ b/event/regular/1945BSN.EVN
@@ -325,7 +325,7 @@ info,hometeam,BSN
 info,date,1945/04/19
 info,site,BOS08
 info,number,1
-info,starttime,0:00AM
+info,starttime,0:00PM
 info,daynight,day
 info,umphome,dunnt901
 info,ump1b,henlb101

--- a/event/regular/1948BOS.EVA
+++ b/event/regular/1948BOS.EVA
@@ -6,7 +6,7 @@ info,hometeam,BOS
 info,date,1948/04/19
 info,site,BOS07
 info,number,1
-info,starttime,0:00AM
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mcgob901

--- a/event/regular/1949.EBA
+++ b/event/regular/1949.EBA
@@ -5,7 +5,7 @@ info,hometeam,WS1
 info,site,WAS09
 info,date,1949/04/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mcgob901
@@ -98,7 +98,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1949/04/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,romme101
@@ -195,7 +195,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1949/04/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mcgob901
@@ -294,7 +294,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1949/04/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,summb901
@@ -407,7 +407,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1949/04/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hubbc901
@@ -504,7 +504,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1949/04/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,joner901
@@ -602,7 +602,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1949/04/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,passa901
@@ -695,7 +695,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1949/04/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,grieb901
@@ -802,7 +802,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1949/04/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,berrc103
@@ -896,7 +896,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1949/04/21
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mckib901
@@ -995,7 +995,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1949/04/21
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stevj901
@@ -1106,7 +1106,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1949/04/21
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,papaj901
@@ -1217,7 +1217,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1949/04/21
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,boyej901
@@ -1312,7 +1312,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1949/04/22
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mcgob901
@@ -1431,7 +1431,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1949/04/22
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,summb901
@@ -1528,7 +1528,7 @@ info,hometeam,WS1
 info,site,WAS09
 info,date,1949/04/22
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,romme101
@@ -1628,7 +1628,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1949/04/22
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hubbc901
@@ -1732,7 +1732,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1949/04/23
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,honoj901
@@ -1839,7 +1839,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1949/04/23
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,berrc103
@@ -1962,7 +1962,7 @@ info,hometeam,WS1
 info,site,WAS09
 info,date,1949/04/23
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,passa901
@@ -2064,7 +2064,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1949/04/23
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,joner901
@@ -2176,7 +2176,7 @@ info,hometeam,WS1
 info,site,WAS09
 info,date,1949/04/24
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,boyej901
@@ -2280,7 +2280,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1949/04/24
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hurle901
@@ -2389,7 +2389,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1949/04/24
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,papaj901
@@ -2495,7 +2495,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1949/04/24
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hubbc901
@@ -2592,7 +2592,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1949/04/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mckib901
@@ -2685,7 +2685,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1949/04/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,romme101
@@ -2778,7 +2778,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1949/04/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,grieb901
@@ -2871,7 +2871,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1949/04/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mcgob901
@@ -2985,7 +2985,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1949/04/26
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,berrc103
@@ -3089,7 +3089,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1949/04/26
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,papaj901
@@ -3205,7 +3205,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1949/04/27
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,passa901
@@ -3313,7 +3313,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1949/04/27
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hubbc901
@@ -3431,7 +3431,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1949/04/27
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stevj901
@@ -3533,7 +3533,7 @@ info,hometeam,WS1
 info,site,WAS09
 info,date,1949/04/27
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,joner901
@@ -3644,7 +3644,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1949/04/28
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,boyej901
@@ -3740,7 +3740,7 @@ info,hometeam,WS1
 info,site,WAS09
 info,date,1949/04/28
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hurle901
@@ -3841,7 +3841,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1949/04/28
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,summb901
@@ -3958,7 +3958,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1949/04/29
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mcgob901
@@ -4049,7 +4049,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1949/04/29
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,honoj901
@@ -4157,7 +4157,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1949/04/29
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,romme101
@@ -4257,7 +4257,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1949/04/30
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,grieb901
@@ -4371,7 +4371,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1949/04/30
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,passa901
@@ -4481,7 +4481,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1949/04/30
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,joner901
@@ -4582,7 +4582,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1949/04/30
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,berrc103
@@ -4693,7 +4693,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1949/05/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mckib901
@@ -4793,7 +4793,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1949/05/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stevj901
@@ -4888,7 +4888,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1949/05/01
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hurle901
@@ -5012,7 +5012,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1949/05/01
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,papaj901
@@ -5136,7 +5136,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1949/05/01
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hubbc901
@@ -5263,7 +5263,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1949/05/01
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mcgob901
@@ -5366,7 +5366,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1949/05/03
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,summb901
@@ -5498,7 +5498,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1949/05/03
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,joner901
@@ -5607,7 +5607,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1949/05/03
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,berrc103
@@ -5745,7 +5745,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1949/05/04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,honoj901
@@ -5855,7 +5855,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1949/05/04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,boyej901
@@ -5962,7 +5962,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1949/05/04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,papaj901
@@ -6059,7 +6059,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1949/05/04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hurle901
@@ -6167,7 +6167,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1949/05/05
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,romme101
@@ -6281,7 +6281,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1949/05/05
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,grieb901
@@ -6400,7 +6400,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1949/05/05
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,mcgob901
@@ -6497,7 +6497,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1949/05/05
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hubbc901
@@ -6593,7 +6593,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1949/05/06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stevj901
@@ -6700,7 +6700,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1949/05/06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,berrc103
@@ -6819,7 +6819,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1949/05/06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,joner901
@@ -6934,7 +6934,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1949/05/07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,summb901
@@ -7034,7 +7034,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1949/05/07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,papaj901
@@ -7130,7 +7130,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1949/05/07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hurle901
@@ -7249,7 +7249,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1949/05/07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,passa901
@@ -7355,7 +7355,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1949/05/08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mckib901
@@ -7460,7 +7460,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1949/05/08
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mcgob901
@@ -7554,7 +7554,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1949/05/08
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hubbc901
@@ -7666,7 +7666,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1949/05/08
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,honoj901
@@ -7783,7 +7783,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1949/05/08
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,grieb901
@@ -7881,7 +7881,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1949/05/08
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,berrc103
@@ -7985,7 +7985,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1949/05/08
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,joner901
@@ -8105,7 +8105,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1949/05/09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,boyej901
@@ -8202,7 +8202,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1949/05/10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,papaj901
@@ -8300,7 +8300,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1949/05/10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stevj901
@@ -8393,7 +8393,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1949/05/10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,hurle901
@@ -8502,7 +8502,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1949/05/10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,passa901
@@ -8604,7 +8604,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1949/05/11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,passa901
@@ -8710,7 +8710,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1949/05/11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mcgob901
@@ -8816,7 +8816,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1949/05/11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,summb901
@@ -8910,7 +8910,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1949/05/11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,hubbc901
@@ -9017,7 +9017,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1949/05/12
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,boyej901
@@ -9115,7 +9115,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1949/05/12
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,joner901
@@ -9208,7 +9208,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1949/05/12
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,honoj901
@@ -9314,7 +9314,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1949/05/13
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,romme101
@@ -9431,7 +9431,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1949/05/13
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,hurle901
@@ -9530,7 +9530,7 @@ info,hometeam,WS1
 info,site,WAS09
 info,date,1949/05/14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,berrc103
@@ -9637,7 +9637,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1949/05/14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,grieb901
@@ -9761,7 +9761,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1949/05/14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mcgob901
@@ -9865,7 +9865,7 @@ info,hometeam,WS1
 info,site,WAS09
 info,date,1949/05/15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mckib901
@@ -9959,7 +9959,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1949/05/15
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stevj901
@@ -10084,7 +10084,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1949/05/15
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,passa901
@@ -10175,7 +10175,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1949/05/15
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,joner901
@@ -10283,7 +10283,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1949/05/15
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,boyej901
@@ -10383,7 +10383,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1949/05/15
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,summb901
@@ -10490,7 +10490,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1949/05/15
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hurle901
@@ -10609,7 +10609,7 @@ info,hometeam,WS1
 info,site,WAS09
 info,date,1949/05/16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,papaj901
@@ -10703,7 +10703,7 @@ info,hometeam,WS1
 info,site,WAS09
 info,date,1949/05/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,mcgob901
@@ -10821,7 +10821,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1949/05/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stevj901
@@ -10911,7 +10911,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1949/05/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,hubbc901
@@ -11013,7 +11013,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1949/05/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,romme101
@@ -11117,7 +11117,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1949/05/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,honoj901
@@ -11216,7 +11216,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1949/05/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,passa901
@@ -11324,7 +11324,7 @@ info,hometeam,WS1
 info,site,WAS09
 info,date,1949/05/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,joner901
@@ -11446,7 +11446,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1949/05/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mckib901
@@ -11542,7 +11542,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1949/05/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,berrc103
@@ -11667,7 +11667,7 @@ info,hometeam,WS1
 info,site,WAS09
 info,date,1949/05/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hurle901
@@ -11764,7 +11764,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1949/05/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,grieb901
@@ -11858,7 +11858,7 @@ info,hometeam,WS1
 info,site,WAS09
 info,date,1949/05/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,mcgob901
@@ -11967,7 +11967,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1949/05/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,boyej901
@@ -12062,7 +12062,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1949/05/21
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,summb901
@@ -12159,7 +12159,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1949/05/21
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,romme101
@@ -12263,7 +12263,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1949/05/21
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,papaj901
@@ -12358,7 +12358,7 @@ info,hometeam,WS1
 info,site,WAS09
 info,date,1949/05/21
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,joner901
@@ -12488,7 +12488,7 @@ info,hometeam,WS1
 info,site,WAS09
 info,date,1949/05/22
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,passa901
@@ -12589,7 +12589,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1949/05/22
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hubbc901
@@ -12689,7 +12689,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1949/05/22
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hurle901
@@ -12796,7 +12796,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1949/05/22
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mcgob901
@@ -12915,7 +12915,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1949/05/23
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,mckib901
@@ -13014,7 +13014,7 @@ info,hometeam,WS1
 info,site,WAS09
 info,date,1949/05/23
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,boyej901
@@ -13116,7 +13116,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1949/05/23
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,stevj901
@@ -13220,7 +13220,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1949/05/23
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,berrc103
@@ -13318,7 +13318,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1949/05/24
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,papaj901
@@ -13435,7 +13435,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1949/05/24
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,grieb901
@@ -13550,7 +13550,7 @@ info,hometeam,WS1
 info,site,WAS09
 info,date,1949/05/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,romme101
@@ -13655,7 +13655,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1949/05/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,honoj901
@@ -13752,7 +13752,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1949/05/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hubbc901
@@ -13856,7 +13856,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1949/05/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,joner901
@@ -13960,7 +13960,7 @@ info,hometeam,WS1
 info,site,WAS09
 info,date,1949/05/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,passa901
@@ -14074,7 +14074,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1949/05/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,berrc103
@@ -14179,7 +14179,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1949/05/27
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,summb901
@@ -14277,7 +14277,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1949/05/27
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,honoj901
@@ -14371,7 +14371,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1949/05/27
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,papaj901
@@ -14470,7 +14470,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1949/05/28
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hurle901
@@ -14574,7 +14574,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1949/05/28
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,boyej901
@@ -14678,7 +14678,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1949/05/28
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stevj901
@@ -14770,7 +14770,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1949/05/28
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hubbc901
@@ -14867,7 +14867,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1949/05/29
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,berrc103
@@ -14976,7 +14976,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1949/05/29
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mcgob901
@@ -15071,7 +15071,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1949/05/29
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,romme101
@@ -15170,7 +15170,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1949/05/29
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,grieb901
@@ -15273,7 +15273,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1949/05/29
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,summb901
@@ -15372,7 +15372,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1949/05/30
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,honoj901
@@ -15466,7 +15466,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1949/05/30
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mckib901
@@ -15580,7 +15580,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1949/05/30
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,papaj901
@@ -15688,7 +15688,7 @@ info,hometeam,WS1
 info,site,WAS09
 info,date,1949/05/30
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,passa901
@@ -15793,7 +15793,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1949/05/30
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stevj901
@@ -15896,7 +15896,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1949/05/30
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,joner901
@@ -15987,7 +15987,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1949/05/30
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hubbc901
@@ -16080,7 +16080,7 @@ info,hometeam,WS1
 info,site,WAS09
 info,date,1949/05/30
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,boyej901
@@ -16194,7 +16194,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1949/06/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,romme101
@@ -16296,7 +16296,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1949/06/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,hurle901
@@ -16396,7 +16396,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1949/06/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,grieb901
@@ -16487,7 +16487,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1949/06/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,berrc103
@@ -16591,7 +16591,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1949/06/02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,papaj901
@@ -16705,7 +16705,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1949/06/02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,honoj901
@@ -16818,7 +16818,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1949/06/02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,passa901
@@ -16934,7 +16934,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1949/06/02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,mcgob901
@@ -17032,7 +17032,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1949/06/03
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,hubbc901
@@ -17141,7 +17141,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1949/06/03
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,boyej901
@@ -17271,7 +17271,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1949/06/03
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mckib901
@@ -17370,7 +17370,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1949/06/03
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,honoj901
@@ -17473,7 +17473,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1949/06/04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,romme101
@@ -17567,7 +17567,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1949/06/04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,berrc103
@@ -17675,7 +17675,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1949/06/04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,joner901
@@ -17777,7 +17777,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1949/06/04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stevj901
@@ -17906,7 +17906,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1949/06/05
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,passa901
@@ -18022,7 +18022,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1949/06/05
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hurle901
@@ -18120,7 +18120,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1949/06/05
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,papaj901
@@ -18221,7 +18221,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1949/06/05
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,grieb901
@@ -18319,7 +18319,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1949/06/05
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mcgob901
@@ -18425,7 +18425,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1949/06/05
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,summb901
@@ -18526,7 +18526,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1949/06/05
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hubbc901
@@ -18636,7 +18636,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1949/06/05
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,boyej901
@@ -18746,7 +18746,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1949/06/06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,mckib901
@@ -18860,7 +18860,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1949/06/06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,honoj901
@@ -18984,7 +18984,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1949/06/07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,berrc103
@@ -19085,7 +19085,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1949/06/07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,stevj901
@@ -19203,7 +19203,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1949/06/07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,joner901
@@ -19297,7 +19297,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1949/06/07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,romme101
@@ -19384,7 +19384,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1949/06/08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,papaj901
@@ -19479,7 +19479,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1949/06/08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,hurle901
@@ -19573,7 +19573,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1949/06/08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,passa901
@@ -19672,7 +19672,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1949/06/08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,grieb901
@@ -19777,7 +19777,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1949/06/09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,boyej901
@@ -19882,7 +19882,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1949/06/09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mcgob901
@@ -19982,7 +19982,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1949/06/09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hubbc901
@@ -20077,7 +20077,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1949/06/10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,berrc103
@@ -20181,7 +20181,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1949/06/10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,summb901
@@ -20279,7 +20279,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1949/06/11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,honoj901
@@ -20392,7 +20392,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1949/06/11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mckib901
@@ -20517,7 +20517,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1949/06/12
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,papaj901
@@ -20624,7 +20624,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1949/06/12
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,joner901
@@ -20722,7 +20722,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1949/06/12
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,romme101
@@ -20831,7 +20831,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1949/06/12
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stevj901
@@ -20927,7 +20927,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1949/06/12
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hurle901
@@ -21033,7 +21033,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1949/06/12
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,grieb901
@@ -21130,7 +21130,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1949/06/12
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hubbc901
@@ -21227,7 +21227,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1949/06/12
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,passa901
@@ -21344,7 +21344,7 @@ info,hometeam,WS1
 info,site,WAS09
 info,date,1949/06/14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,mcgob901
@@ -21440,7 +21440,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1949/06/14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,summb901
@@ -21532,7 +21532,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1949/06/14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,berrc103
@@ -21643,7 +21643,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1949/06/14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,boyej901
@@ -21743,7 +21743,7 @@ info,hometeam,WS1
 info,site,WAS09
 info,date,1949/06/15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,mckib901
@@ -21838,7 +21838,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1949/06/15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,romme101
@@ -21947,7 +21947,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1949/06/15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,honoj901
@@ -22048,7 +22048,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1949/06/15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,papaj901
@@ -22153,7 +22153,7 @@ info,hometeam,WS1
 info,site,WAS09
 info,date,1949/06/16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,joner901
@@ -22249,7 +22249,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1949/06/16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,grieb901
@@ -22344,7 +22344,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1949/06/16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stevj901
@@ -22442,7 +22442,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1949/06/16
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hubbc901
@@ -22563,7 +22563,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1949/06/16
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,berrc103
@@ -22659,7 +22659,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1949/06/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,papaj901
@@ -22771,7 +22771,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1949/06/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,summb901
@@ -22876,7 +22876,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1949/06/17
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,passa901
@@ -22972,7 +22972,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1949/06/17
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,boyej901
@@ -23088,7 +23088,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1949/06/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,romme101
@@ -23188,7 +23188,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1949/06/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hubbc901
@@ -23303,7 +23303,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1949/06/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,grieb901
@@ -23402,7 +23402,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1949/06/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,passa901
@@ -23497,7 +23497,7 @@ info,hometeam,WS1
 info,site,WAS09
 info,date,1949/06/19
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hurle901
@@ -23605,7 +23605,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1949/06/19
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stevj901
@@ -23699,7 +23699,7 @@ info,hometeam,WS1
 info,site,WAS09
 info,date,1949/06/19
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mcgob901
@@ -23795,7 +23795,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1949/06/19
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,honoj901
@@ -23898,7 +23898,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1949/06/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,boyej901
@@ -24006,7 +24006,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1949/06/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,berrc103
@@ -24110,7 +24110,7 @@ info,hometeam,WS1
 info,site,WAS09
 info,date,1949/06/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,summb901
@@ -24206,7 +24206,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1949/06/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mckib901
@@ -24309,7 +24309,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1949/06/21
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,mcgob901
@@ -24411,7 +24411,7 @@ info,hometeam,WS1
 info,site,WAS09
 info,date,1949/06/21
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,stevj901
@@ -24514,7 +24514,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1949/06/21
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,papaj901
@@ -24610,7 +24610,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1949/06/22
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,hurle901
@@ -24729,7 +24729,7 @@ info,hometeam,WS1
 info,site,WAS09
 info,date,1949/06/22
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,grieb901
@@ -24830,7 +24830,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1949/06/22
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hubbc901
@@ -24941,7 +24941,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1949/06/22
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,romme101
@@ -25047,7 +25047,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1949/06/22
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,passa901
@@ -25164,7 +25164,7 @@ info,hometeam,WS1
 info,site,WAS09
 info,date,1949/06/23
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,honoj901
@@ -25272,7 +25272,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1949/06/23
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,boyej901
@@ -25380,7 +25380,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1949/06/23
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,mcgob901
@@ -25487,7 +25487,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1949/06/23
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,berrc103
@@ -25581,7 +25581,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1949/06/24
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,papaj901
@@ -25681,7 +25681,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1949/06/24
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,romme101
@@ -25799,7 +25799,7 @@ info,hometeam,WS1
 info,site,WAS09
 info,date,1949/06/24
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,summb901
@@ -25903,7 +25903,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1949/06/24
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,mckib901
@@ -25998,7 +25998,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1949/06/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hubbc901
@@ -26099,7 +26099,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1949/06/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,joner901
@@ -26194,7 +26194,7 @@ info,hometeam,WS1
 info,site,WAS09
 info,date,1949/06/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stevj901
@@ -26305,7 +26305,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1949/06/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,passa901
@@ -26416,7 +26416,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1949/06/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,berrc103
@@ -26513,7 +26513,7 @@ info,hometeam,WS1
 info,site,WAS09
 info,date,1949/06/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,grieb901
@@ -26603,7 +26603,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1949/06/26
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,boyej901
@@ -26702,7 +26702,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1949/06/26
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hurle901
@@ -26804,7 +26804,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1949/06/26
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mcgob901
@@ -26920,7 +26920,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1949/06/26
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,romme101
@@ -27023,7 +27023,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1949/06/28
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,mckib901
@@ -27137,7 +27137,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1949/06/28
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,passa901
@@ -27238,7 +27238,7 @@ info,hometeam,WS1
 info,site,WAS09
 info,date,1949/06/28
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,papaj901
@@ -27341,7 +27341,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1949/06/28
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,summb901
@@ -27442,7 +27442,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1949/06/29
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,joner901
@@ -27529,7 +27529,7 @@ info,hometeam,WS1
 info,site,WAS09
 info,date,1949/06/29
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,hubbc901
@@ -27638,7 +27638,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1949/06/29
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stevj901
@@ -27756,7 +27756,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1949/06/29
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,boyej901
@@ -27861,7 +27861,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1949/06/29
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,romme101
@@ -27984,7 +27984,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1949/06/30
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,grieb901
@@ -28094,7 +28094,7 @@ info,hometeam,WS1
 info,site,WAS09
 info,date,1949/06/30
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,berrc103
@@ -28194,7 +28194,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1949/06/30
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,passa901
@@ -28304,7 +28304,7 @@ info,hometeam,WS1
 info,site,WAS09
 info,date,1949/07/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,papaj901
@@ -28420,7 +28420,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1949/07/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,honoj901
@@ -28521,7 +28521,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1949/07/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,boyej901
@@ -28613,7 +28613,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1949/07/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,hurle901
@@ -28717,7 +28717,7 @@ info,hometeam,WS1
 info,site,WAS09
 info,date,1949/07/02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hubbc901
@@ -28826,7 +28826,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1949/07/02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,romme101
@@ -28931,7 +28931,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1949/07/02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,summb901
@@ -29026,7 +29026,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1949/07/02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mcgob901
@@ -29137,7 +29137,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1949/07/03
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mckib901
@@ -29249,7 +29249,7 @@ info,hometeam,WS1
 info,site,WAS09
 info,date,1949/07/03
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,berrc103
@@ -29372,7 +29372,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1949/07/03
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stevj901
@@ -29469,7 +29469,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1949/07/03
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,passa901
@@ -29567,7 +29567,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1949/07/03
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,boyej901
@@ -29674,7 +29674,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1949/07/04
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,joner901
@@ -29780,7 +29780,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1949/07/04
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,romme101
@@ -29891,7 +29891,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1949/07/04
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,papaj901
@@ -29991,7 +29991,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1949/07/04
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,grieb901
@@ -30110,7 +30110,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1949/07/04
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,honoj901
@@ -30205,7 +30205,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1949/07/04
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hurle901
@@ -30312,7 +30312,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1949/07/04
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hubbc901
@@ -30407,7 +30407,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1949/07/04
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,passa901
@@ -30509,7 +30509,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1949/07/05
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,mcgob901
@@ -30612,7 +30612,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1949/07/05
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,berrc103
@@ -30714,7 +30714,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1949/07/05
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,boyej901
@@ -30813,7 +30813,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1949/07/06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,romme101
@@ -30920,7 +30920,7 @@ info,hometeam,WS1
 info,site,WAS09
 info,date,1949/07/06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,stevj901
@@ -31011,7 +31011,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1949/07/06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,mckib901
@@ -31125,7 +31125,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1949/07/07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,papaj901
@@ -31218,7 +31218,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1949/07/07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,joner901
@@ -31317,7 +31317,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1949/07/07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,passa901
@@ -31421,7 +31421,7 @@ info,hometeam,WS1
 info,site,WAS09
 info,date,1949/07/07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,summb901
@@ -31541,7 +31541,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1949/07/08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,hubbc901
@@ -31642,7 +31642,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1949/07/08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,boyej901
@@ -31743,7 +31743,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1949/07/08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,hurle901
@@ -31869,7 +31869,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1949/07/08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,grieb901
@@ -31996,7 +31996,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1949/07/09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,berrc103
@@ -32102,7 +32102,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1949/07/09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,honoj901
@@ -32210,7 +32210,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1949/07/10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mcgob901
@@ -32303,7 +32303,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1949/07/10
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,papaj901
@@ -32395,7 +32395,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1949/07/10
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,romme101
@@ -32492,7 +32492,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1949/07/10
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,passa901
@@ -32583,7 +32583,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1949/07/10
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hubbc901
@@ -32695,7 +32695,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1949/07/14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,stevj901
@@ -32802,7 +32802,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1949/07/14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,mckib901
@@ -32908,7 +32908,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1949/07/14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,boyej901
@@ -33003,7 +33003,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1949/07/14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,berrc103
@@ -33098,7 +33098,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1949/07/15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,summb901
@@ -33210,7 +33210,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1949/07/15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,romme101
@@ -33303,7 +33303,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1949/07/15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,papaj901
@@ -33405,7 +33405,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1949/07/15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,joner901
@@ -33515,7 +33515,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1949/07/16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hurle901
@@ -33619,7 +33619,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1949/07/16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hubbc901
@@ -33736,7 +33736,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1949/07/16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,grieb901
@@ -33839,7 +33839,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1949/07/16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,passa901
@@ -33929,7 +33929,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1949/07/17
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mcgob901
@@ -34024,7 +34024,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1949/07/17
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,boyej901
@@ -34138,7 +34138,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1949/07/17
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,berrc103
@@ -34229,7 +34229,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1949/07/17
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,honoj901
@@ -34321,7 +34321,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1949/07/17
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,romme101
@@ -34423,7 +34423,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1949/07/17
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stevj901
@@ -34525,7 +34525,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1949/07/17
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,papaj901
@@ -34622,7 +34622,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1949/07/17
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mckib901
@@ -34740,7 +34740,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1949/07/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,joner901
@@ -34862,7 +34862,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1949/07/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,summb901
@@ -34979,7 +34979,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1949/07/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,hubbc901
@@ -35073,7 +35073,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1949/07/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,passa901
@@ -35177,7 +35177,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1949/07/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hurle901
@@ -35277,7 +35277,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1949/07/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,berrc103
@@ -35397,7 +35397,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1949/07/19
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,summb901
@@ -35494,7 +35494,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1949/07/19
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,grieb901
@@ -35620,7 +35620,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1949/07/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,romme101
@@ -35726,7 +35726,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1949/07/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,mcgob901
@@ -35842,7 +35842,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1949/07/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,papaj901
@@ -35949,7 +35949,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1949/07/21
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mckib901
@@ -36054,7 +36054,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1949/07/21
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hubbc901
@@ -36166,7 +36166,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1949/07/21
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,summb901
@@ -36270,7 +36270,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1949/07/21
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,grieb901
@@ -36376,7 +36376,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1949/07/22
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,honoj901
@@ -36471,7 +36471,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1949/07/22
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,passa901
@@ -36564,7 +36564,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1949/07/22
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,joner901
@@ -36658,7 +36658,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1949/07/22
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,berrc103
@@ -36771,7 +36771,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1949/07/23
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hurle901
@@ -36876,7 +36876,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1949/07/23
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,summb901
@@ -36975,7 +36975,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1949/07/23
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,papaj901
@@ -37069,7 +37069,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1949/07/24
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hubbc901
@@ -37196,7 +37196,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1949/07/24
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mcgob901
@@ -37303,7 +37303,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1949/07/24
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,grieb901
@@ -37426,7 +37426,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1949/07/24
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stevj901
@@ -37527,7 +37527,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1949/07/24
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,honoj901
@@ -37637,7 +37637,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1949/07/24
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mckib901
@@ -37737,7 +37737,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1949/07/24
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,romme101
@@ -37835,7 +37835,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1949/07/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,joner901
@@ -37933,7 +37933,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1949/07/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,berrc103
@@ -38027,7 +38027,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1949/07/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,summb901
@@ -38132,7 +38132,7 @@ info,hometeam,WS1
 info,site,WAS09
 info,date,1949/07/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,passa901
@@ -38230,7 +38230,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1949/07/27
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,grieb901
@@ -38324,7 +38324,7 @@ info,hometeam,WS1
 info,site,WAS09
 info,date,1949/07/27
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stevj901
@@ -38438,7 +38438,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1949/07/27
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,papaj901
@@ -38539,7 +38539,7 @@ info,hometeam,WS1
 info,site,WAS09
 info,date,1949/07/27
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,romme101
@@ -38637,7 +38637,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1949/07/27
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hubbc901
@@ -38746,7 +38746,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1949/07/28
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hurle901
@@ -38853,7 +38853,7 @@ info,hometeam,WS1
 info,site,WAS09
 info,date,1949/07/28
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,boyej901
@@ -38972,7 +38972,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1949/07/28
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,honoj901
@@ -39060,7 +39060,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1949/07/29
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,berrc103
@@ -39158,7 +39158,7 @@ info,hometeam,WS1
 info,site,WAS09
 info,date,1949/07/29
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,passa901
@@ -39277,7 +39277,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1949/07/29
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,joner901
@@ -39382,7 +39382,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1949/07/29
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,summb901
@@ -39478,7 +39478,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1949/07/29
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,grieb901
@@ -39578,7 +39578,7 @@ info,hometeam,WS1
 info,site,WAS09
 info,date,1949/07/30
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stevj901
@@ -39699,7 +39699,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1949/07/30
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mckib901
@@ -39811,7 +39811,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1949/07/30
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,papaj901
@@ -39919,7 +39919,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1949/07/30
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,honoj901
@@ -40031,7 +40031,7 @@ info,hometeam,WS1
 info,site,WAS09
 info,date,1949/07/31
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,romme101
@@ -40135,7 +40135,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1949/07/31
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,summb901
@@ -40230,7 +40230,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1949/07/31
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hubbc901
@@ -40328,7 +40328,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1949/07/31
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mcgob901
@@ -40422,7 +40422,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1949/07/31
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hurle901
@@ -40519,7 +40519,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1949/07/31
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,berrc103
@@ -40624,7 +40624,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1949/08/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,grieb901
@@ -40714,7 +40714,7 @@ info,hometeam,WS1
 info,site,WAS09
 info,date,1949/08/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,boyej901
@@ -40810,7 +40810,7 @@ info,hometeam,WS1
 info,site,WAS09
 info,date,1949/08/02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,papaj901
@@ -40904,7 +40904,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1949/08/02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,joner901
@@ -41001,7 +41001,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1949/08/02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,passa901
@@ -41096,7 +41096,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1949/08/02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,honoj901
@@ -41203,7 +41203,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1949/08/03
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,stevj901
@@ -41294,7 +41294,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1949/08/03
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mckib901
@@ -41405,7 +41405,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1949/08/03
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,summb901
@@ -41507,7 +41507,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1949/08/04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mcgob901
@@ -41612,7 +41612,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1949/08/04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,grieb901
@@ -41711,7 +41711,7 @@ info,hometeam,WS1
 info,site,WAS09
 info,date,1949/08/04
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hubbc901
@@ -41833,7 +41833,7 @@ info,hometeam,WS1
 info,site,WAS09
 info,date,1949/08/04
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,berrc103
@@ -41943,7 +41943,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1949/08/05
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,romme101
@@ -42043,7 +42043,7 @@ info,hometeam,WS1
 info,site,WAS09
 info,date,1949/08/05
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,papaj901
@@ -42137,7 +42137,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1949/08/05
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,hurle901
@@ -42242,7 +42242,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1949/08/05
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,honoj901
@@ -42346,7 +42346,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1949/08/05
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,summb901
@@ -42474,7 +42474,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1949/08/06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,boyej901
@@ -42567,7 +42567,7 @@ info,hometeam,WS1
 info,site,WAS09
 info,date,1949/08/06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hubbc901
@@ -42677,7 +42677,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1949/08/06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,joner901
@@ -42774,7 +42774,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1949/08/06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,grieb901
@@ -42899,7 +42899,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1949/08/07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mckib901
@@ -43002,7 +43002,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1949/08/07
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,romme101
@@ -43116,7 +43116,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1949/08/07
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,honoj901
@@ -43242,7 +43242,7 @@ info,hometeam,WS1
 info,site,WAS09
 info,date,1949/08/07
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,berrc103
@@ -43337,7 +43337,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1949/08/07
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,summb901
@@ -43443,7 +43443,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1949/08/07
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stevj901
@@ -43550,7 +43550,7 @@ info,hometeam,WS1
 info,site,WAS09
 info,date,1949/08/07
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,papaj901
@@ -43646,7 +43646,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1949/08/09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,boyej901
@@ -43740,7 +43740,7 @@ info,hometeam,WS1
 info,site,WAS09
 info,date,1949/08/09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,mcgob901
@@ -43841,7 +43841,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1949/08/09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,grieb901
@@ -43952,7 +43952,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1949/08/09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,hubbc901
@@ -44060,7 +44060,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1949/08/10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,honoj901
@@ -44169,7 +44169,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1949/08/10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,berrc103
@@ -44277,7 +44277,7 @@ info,hometeam,WS1
 info,site,WAS09
 info,date,1949/08/10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,hurle901
@@ -44392,7 +44392,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1949/08/10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,passa901
@@ -44490,7 +44490,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1949/08/11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,romme101
@@ -44608,7 +44608,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1949/08/11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,papaj901
@@ -44739,7 +44739,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1949/08/12
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,hubbc901
@@ -44854,7 +44854,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1949/08/12
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,summb901
@@ -44957,7 +44957,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1949/08/12
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,joner901
@@ -45048,7 +45048,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1949/08/12
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,boyej901
@@ -45155,7 +45155,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1949/08/12
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stevj901
@@ -45268,7 +45268,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1949/08/13
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,passa901
@@ -45368,7 +45368,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1949/08/13
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,grieb901
@@ -45504,7 +45504,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1949/08/13
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mckib901
@@ -45622,7 +45622,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1949/08/14
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,honoj901
@@ -45719,7 +45719,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1949/08/14
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mcgob901
@@ -45819,7 +45819,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1949/08/14
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,romme101
@@ -45916,7 +45916,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1949/08/14
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,berrc103
@@ -46019,7 +46019,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1949/08/14
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,papaj901
@@ -46117,7 +46117,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1949/08/14
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stevj901
@@ -46216,7 +46216,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1949/08/14
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,joner901
@@ -46312,7 +46312,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1949/08/14
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,summb901
@@ -46407,7 +46407,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1949/08/15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,grieb901
@@ -46510,7 +46510,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1949/08/15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,boyej901
@@ -46612,7 +46612,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1949/08/15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,hubbc901
@@ -46709,7 +46709,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1949/08/15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hurle901
@@ -46817,7 +46817,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1949/08/16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,honoj901
@@ -46911,7 +46911,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1949/08/16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,berrc103
@@ -46998,7 +46998,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1949/08/16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,mckib901
@@ -47091,7 +47091,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1949/08/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,passa901
@@ -47193,7 +47193,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1949/08/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,mcgob901
@@ -47288,7 +47288,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1949/08/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,papaj901
@@ -47385,7 +47385,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1949/08/17
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,summb901
@@ -47506,7 +47506,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1949/08/17
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,grieb901
@@ -47628,7 +47628,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1949/08/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,romme101
@@ -47739,7 +47739,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1949/08/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,honoj901
@@ -47851,7 +47851,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1949/08/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hubbc901
@@ -47955,7 +47955,7 @@ info,hometeam,WS1
 info,site,WAS09
 info,date,1949/08/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,joner901
@@ -48060,7 +48060,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1949/08/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,stevj901
@@ -48171,7 +48171,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1949/08/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,berrc103
@@ -48278,7 +48278,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1949/08/19
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,summb901
@@ -48393,7 +48393,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1949/08/19
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,grieb901
@@ -48479,7 +48479,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1949/08/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,boyej901
@@ -48584,7 +48584,7 @@ info,hometeam,WS1
 info,site,WAS09
 info,date,1949/08/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hurle901
@@ -48678,7 +48678,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1949/08/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,summb901
@@ -48779,7 +48779,7 @@ info,hometeam,WS1
 info,site,WAS09
 info,date,1949/08/21
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mckib901
@@ -48875,7 +48875,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1949/08/21
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,passa901
@@ -48982,7 +48982,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1949/08/21
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,papaj901
@@ -49093,7 +49093,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1949/08/21
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,summb901
@@ -49205,7 +49205,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1949/08/21
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,grieb901
@@ -49336,7 +49336,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1949/08/21
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hubbc901
@@ -49451,7 +49451,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1949/08/23
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,honoj901
@@ -49557,7 +49557,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1949/08/23
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,romme101
@@ -49663,7 +49663,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1949/08/23
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,mcgob901
@@ -49776,7 +49776,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1949/08/23
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,berrc103
@@ -49882,7 +49882,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1949/08/24
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,summb901
@@ -49984,7 +49984,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1949/08/24
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stevj901
@@ -50091,7 +50091,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1949/08/24
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,joner901
@@ -50188,7 +50188,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1949/08/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,grieb901
@@ -50306,7 +50306,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1949/08/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,papaj901
@@ -50415,7 +50415,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1949/08/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hurle901
@@ -50520,7 +50520,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1949/08/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,passa901
@@ -50612,7 +50612,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1949/08/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,honoj901
@@ -50711,7 +50711,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1949/08/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,romme101
@@ -50814,7 +50814,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1949/08/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,hubbc901
@@ -50922,7 +50922,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1949/08/26
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mcgob901
@@ -51030,7 +51030,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1949/08/26
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,boyej901
@@ -51129,7 +51129,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1949/08/27
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stevj901
@@ -51246,7 +51246,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1949/08/27
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,joner901
@@ -51348,7 +51348,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1949/08/27
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,berrc103
@@ -51442,7 +51442,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1949/08/27
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mckib901
@@ -51540,7 +51540,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1949/08/28
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,passa901
@@ -51634,7 +51634,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1949/08/28
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,summb901
@@ -51732,7 +51732,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1949/08/28
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,boyej901
@@ -51870,7 +51870,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1949/08/28
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hurle901
@@ -51978,7 +51978,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1949/08/28
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,papaj901
@@ -52079,7 +52079,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1949/08/28
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,joner901
@@ -52179,7 +52179,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1949/08/29
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,mcgob901
@@ -52278,7 +52278,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1949/08/29
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,grieb901
@@ -52372,7 +52372,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1949/08/29
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,romme101
@@ -52474,7 +52474,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1949/08/29
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stevj901
@@ -52586,7 +52586,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1949/08/30
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,honoj901
@@ -52686,7 +52686,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1949/08/30
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hubbc901
@@ -52779,7 +52779,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1949/08/30
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,hurle901
@@ -52881,7 +52881,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1949/08/31
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,joner901
@@ -52984,7 +52984,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1949/08/31
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,summb901
@@ -53092,7 +53092,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1949/08/31
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,berrc103
@@ -53186,7 +53186,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1949/08/31
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,passa901
@@ -53299,7 +53299,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1949/08/31
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,romme101
@@ -53396,7 +53396,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1949/09/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,papaj901
@@ -53500,7 +53500,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1949/09/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mcgob901
@@ -53615,7 +53615,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1949/09/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,boyej901
@@ -53721,7 +53721,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1949/09/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mckib901
@@ -53814,7 +53814,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1949/09/02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,stevj901
@@ -53920,7 +53920,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1949/09/02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hurle901
@@ -54019,7 +54019,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1949/09/03
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,grieb901
@@ -54120,7 +54120,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1949/09/03
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,joner901
@@ -54229,7 +54229,7 @@ info,hometeam,WS1
 info,site,WAS09
 info,date,1949/09/03
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hubbc901
@@ -54324,7 +54324,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1949/09/03
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,passa901
@@ -54423,7 +54423,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1949/09/04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mcgob901
@@ -54513,7 +54513,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1949/09/04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,romme101
@@ -54610,7 +54610,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1949/09/04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,honoj901
@@ -54709,7 +54709,7 @@ info,hometeam,WS1
 info,site,WAS09
 info,date,1949/09/04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,berrc103
@@ -54815,7 +54815,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1949/09/05
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hurle901
@@ -54913,7 +54913,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1949/09/05
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,papaj901
@@ -55025,7 +55025,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1949/09/05
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mckib901
@@ -55133,7 +55133,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1949/09/05
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,boyej901
@@ -55228,7 +55228,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1949/09/05
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stevj901
@@ -55330,7 +55330,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1949/09/05
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,grieb901
@@ -55436,7 +55436,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1949/09/05
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hubbc901
@@ -55542,7 +55542,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1949/09/05
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,joner901
@@ -55630,7 +55630,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1949/09/07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,honoj901
@@ -55734,7 +55734,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1949/09/07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,passa901
@@ -55836,7 +55836,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1949/09/08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mckib901
@@ -55941,7 +55941,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1949/09/08
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mcgob901
@@ -56043,7 +56043,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1949/09/08
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,berrc103
@@ -56141,7 +56141,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1949/09/08
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hurle901
@@ -56232,7 +56232,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1949/09/08
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,papaj901
@@ -56333,7 +56333,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1949/09/09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,romme101
@@ -56432,7 +56432,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1949/09/09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,joner901
@@ -56540,7 +56540,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1949/09/09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hubbc901
@@ -56636,7 +56636,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1949/09/10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,joner901
@@ -56736,7 +56736,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1949/09/10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,berrc103
@@ -56831,7 +56831,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1949/09/10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,grieb901
@@ -56930,7 +56930,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1949/09/10
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,boyej901
@@ -57038,7 +57038,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1949/09/10
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stevj901
@@ -57134,7 +57134,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1949/09/11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hurle901
@@ -57257,7 +57257,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1949/09/11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,honoj901
@@ -57346,7 +57346,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1949/09/11
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,passa901
@@ -57462,7 +57462,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1949/09/11
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,papaj901
@@ -57563,7 +57563,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1949/09/11
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hubbc901
@@ -57664,7 +57664,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1949/09/11
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,romme101
@@ -57756,7 +57756,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1949/09/13
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mckib901
@@ -57863,7 +57863,7 @@ info,hometeam,WS1
 info,site,WAS09
 info,date,1949/09/13
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,mcgob901
@@ -57970,7 +57970,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1949/09/14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,grieb901
@@ -58076,7 +58076,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1949/09/14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,boyej901
@@ -58165,7 +58165,7 @@ info,hometeam,WS1
 info,site,WAS09
 info,date,1949/09/14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,joner901
@@ -58272,7 +58272,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1949/09/14
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stevj901
@@ -58368,7 +58368,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1949/09/14
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,papaj901
@@ -58493,7 +58493,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1949/09/15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hubbc901
@@ -58597,7 +58597,7 @@ info,hometeam,WS1
 info,site,WAS09
 info,date,1949/09/16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,hurle901
@@ -58705,7 +58705,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1949/09/16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stevj901
@@ -58802,7 +58802,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1949/09/16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,honoj901
@@ -58905,7 +58905,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1949/09/16
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,passa901
@@ -59002,7 +59002,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1949/09/16
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,romme101
@@ -59111,7 +59111,7 @@ info,hometeam,WS1
 info,site,WAS09
 info,date,1949/09/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mcgob901
@@ -59209,7 +59209,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1949/09/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,boyej901
@@ -59311,7 +59311,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1949/09/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mckib901
@@ -59416,7 +59416,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1949/09/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,berrc103
@@ -59528,7 +59528,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1949/09/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,papaj901
@@ -59638,7 +59638,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1949/09/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,summb901
@@ -59761,7 +59761,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1949/09/18
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,joner901
@@ -59857,7 +59857,7 @@ info,hometeam,WS1
 info,site,WAS09
 info,date,1949/09/18
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,passa901
@@ -59964,7 +59964,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1949/09/18
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hurle901
@@ -60066,7 +60066,7 @@ info,hometeam,WS1
 info,site,WAS09
 info,date,1949/09/18
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,romme101
@@ -60162,7 +60162,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1949/09/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mcgob901
@@ -60258,7 +60258,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1949/09/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,grieb901
@@ -60367,7 +60367,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1949/09/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hubbc901
@@ -60469,7 +60469,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1949/09/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,honoj901
@@ -60578,7 +60578,7 @@ info,hometeam,WS1
 info,site,WAS09
 info,date,1949/09/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,boyej901
@@ -60699,7 +60699,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1949/09/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,joner901
@@ -60813,7 +60813,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1949/09/21
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mckib901
@@ -60956,7 +60956,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1949/09/21
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hurle901
@@ -61050,7 +61050,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1949/09/21
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stevj901
@@ -61173,7 +61173,7 @@ info,hometeam,WS1
 info,site,WAS09
 info,date,1949/09/21
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,passa901
@@ -61276,7 +61276,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1949/09/23
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,mcgob901
@@ -61376,7 +61376,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1949/09/23
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,romme101
@@ -61475,7 +61475,7 @@ info,hometeam,WS1
 info,site,WAS09
 info,date,1949/09/23
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,summb901
@@ -61623,7 +61623,7 @@ info,hometeam,WS1
 info,site,WAS09
 info,date,1949/09/23
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,grieb901
@@ -61720,7 +61720,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1949/09/24
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,berrc103
@@ -61816,7 +61816,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1949/09/24
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,passa901
@@ -61924,7 +61924,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1949/09/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,papaj901
@@ -62030,7 +62030,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1949/09/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,joner901
@@ -62131,7 +62131,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1949/09/25
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hurle901
@@ -62250,7 +62250,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1949/09/25
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stevj901
@@ -62354,7 +62354,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1949/09/25
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,boyej901
@@ -62462,7 +62462,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1949/09/25
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,honoj901
@@ -62552,7 +62552,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1949/09/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,grieb901
@@ -62680,7 +62680,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1949/09/27
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,hurle901
@@ -62792,7 +62792,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1949/09/27
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hubbc901
@@ -62887,7 +62887,7 @@ info,hometeam,WS1
 info,site,WAS09
 info,date,1949/09/27
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,summb901
@@ -62993,7 +62993,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1949/09/28
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,berrc103
@@ -63120,7 +63120,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1949/09/28
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mckib901
@@ -63224,7 +63224,7 @@ info,hometeam,WS1
 info,site,WAS09
 info,date,1949/09/28
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,romme101
@@ -63326,7 +63326,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1949/09/29
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,boyej901
@@ -63429,7 +63429,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1949/09/30
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hubbc901
@@ -63545,7 +63545,7 @@ info,hometeam,WS1
 info,site,WAS09
 info,date,1949/09/30
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,grieb901
@@ -63663,7 +63663,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1949/09/30
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mcgob901
@@ -63762,7 +63762,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1949/10/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,passa901
@@ -63863,7 +63863,7 @@ info,hometeam,WS1
 info,site,WAS09
 info,date,1949/10/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,grieb901
@@ -63956,7 +63956,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1949/10/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mckib901
@@ -64063,7 +64063,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1949/10/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,summb901
@@ -64171,7 +64171,7 @@ info,hometeam,WS1
 info,site,WAS09
 info,date,1949/10/02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,papaj901
@@ -64269,7 +64269,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1949/10/02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hubbc901
@@ -64378,7 +64378,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1949/10/02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,joner901
@@ -64476,7 +64476,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1949/10/02
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,boyej901
@@ -64598,7 +64598,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1949/10/02
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mckib901

--- a/event/regular/1949.EBN
+++ b/event/regular/1949.EBN
@@ -5,7 +5,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1949/04/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stewb901
@@ -95,7 +95,7 @@ info,hometeam,BRO
 info,site,NYC15
 info,date,1949/04/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,pineb101
@@ -196,7 +196,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1949/04/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barrg901
@@ -305,7 +305,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1949/04/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,rearb901
@@ -406,7 +406,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1949/04/19
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,conlj102
@@ -503,7 +503,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1949/04/19
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,warnl101
@@ -610,7 +610,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1949/04/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,goetl901
@@ -711,7 +711,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1949/04/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stewb901
@@ -814,7 +814,7 @@ info,hometeam,BRO
 info,site,NYC15
 info,date,1949/04/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,gorea901
@@ -918,7 +918,7 @@ info,hometeam,BRO
 info,site,NYC15
 info,date,1949/04/21
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,robbs901
@@ -1012,7 +1012,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1949/04/21
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,jordl901
@@ -1110,7 +1110,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1949/04/21
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,balll901
@@ -1211,7 +1211,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1949/04/22
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barla901
@@ -1319,7 +1319,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1949/04/22
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,rearb901
@@ -1422,7 +1422,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1949/04/22
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dascf901
@@ -1539,7 +1539,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1949/04/23
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,goetl901
@@ -1669,7 +1669,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1949/04/23
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,pineb101
@@ -1777,7 +1777,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1949/04/23
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,conlj102
@@ -1892,7 +1892,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1949/04/24
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,gorea901
@@ -1990,7 +1990,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1949/04/24
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,jordl901
@@ -2103,7 +2103,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1949/04/24
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barrg901
@@ -2204,7 +2204,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1949/04/24
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,warnl101
@@ -2307,7 +2307,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1949/04/24
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stewb901
@@ -2415,7 +2415,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1949/04/24
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,balll901
@@ -2524,7 +2524,7 @@ info,hometeam,BRO
 info,site,NYC15
 info,date,1949/04/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,conlj102
@@ -2622,7 +2622,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1949/04/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,rearb901
@@ -2723,7 +2723,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1949/04/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,barla901
@@ -2826,7 +2826,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1949/04/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,robbs901
@@ -2928,7 +2928,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1949/04/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dascf901
@@ -3065,7 +3065,7 @@ info,hometeam,BRO
 info,site,NYC15
 info,date,1949/04/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,warnl101
@@ -3157,7 +3157,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1949/04/27
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stewb901
@@ -3302,7 +3302,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1949/04/27
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barrg901
@@ -3418,7 +3418,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1949/04/27
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,goetl901
@@ -3538,7 +3538,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1949/04/27
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,pineb101
@@ -3635,7 +3635,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1949/04/28
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,balll901
@@ -3730,7 +3730,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1949/04/28
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,gorea901
@@ -3832,7 +3832,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1949/04/28
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,jordl901
@@ -3935,7 +3935,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1949/04/28
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,conlj102
@@ -4056,7 +4056,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1949/04/29
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,rearb901
@@ -4153,7 +4153,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1949/04/29
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,robbs901
@@ -4280,7 +4280,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1949/04/29
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barla901
@@ -4408,7 +4408,7 @@ info,hometeam,BRO
 info,site,NYC15
 info,date,1949/04/29
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,warnl101
@@ -4515,7 +4515,7 @@ info,hometeam,BRO
 info,site,NYC15
 info,date,1949/04/30
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stewb901
@@ -4628,7 +4628,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1949/04/30
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barrg901
@@ -4735,7 +4735,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1949/04/30
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,goetl901
@@ -4859,7 +4859,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1949/04/30
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dascf901
@@ -4955,7 +4955,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1949/05/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,balll901
@@ -5069,7 +5069,7 @@ info,hometeam,BRO
 info,site,NYC15
 info,date,1949/05/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,conlj102
@@ -5178,7 +5178,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1949/05/01
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,jordl901
@@ -5287,7 +5287,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1949/05/01
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,pineb101
@@ -5385,7 +5385,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1949/05/01
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,gorea901
@@ -5490,7 +5490,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1949/05/01
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,rearb901
@@ -5594,7 +5594,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1949/05/03
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,goetl901
@@ -5703,7 +5703,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1949/05/03
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,warnl101
@@ -5799,7 +5799,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1949/05/03
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,robbs901
@@ -5903,7 +5903,7 @@ info,hometeam,BRO
 info,site,NYC15
 info,date,1949/05/03
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barla901
@@ -6003,7 +6003,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1949/05/04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dascf901
@@ -6117,7 +6117,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1949/05/04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,stewb901
@@ -6221,7 +6221,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1949/05/04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,jordl901
@@ -6326,7 +6326,7 @@ info,hometeam,BRO
 info,site,NYC15
 info,date,1949/05/04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barrg901
@@ -6427,7 +6427,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1949/05/05
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,rearb901
@@ -6532,7 +6532,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1949/05/05
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,pineb101
@@ -6644,7 +6644,7 @@ info,hometeam,BRO
 info,site,NYC15
 info,date,1949/05/05
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,balll901
@@ -6749,7 +6749,7 @@ info,hometeam,BRO
 info,site,NYC15
 info,date,1949/05/06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,robbs901
@@ -6852,7 +6852,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1949/05/06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,conlj102
@@ -6950,7 +6950,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1949/05/06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barla901
@@ -7045,7 +7045,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1949/05/06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,goetl901
@@ -7141,7 +7141,7 @@ info,hometeam,BRO
 info,site,NYC15
 info,date,1949/05/07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dascf901
@@ -7250,7 +7250,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1949/05/07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,jordl901
@@ -7350,7 +7350,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1949/05/07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barrg901
@@ -7445,7 +7445,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1949/05/07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,warnl101
@@ -7555,7 +7555,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1949/05/08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,rearb901
@@ -7665,7 +7665,7 @@ info,hometeam,BRO
 info,site,NYC15
 info,date,1949/05/08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stewb901
@@ -7793,7 +7793,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1949/05/08
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,balll901
@@ -7903,7 +7903,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1949/05/08
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,pineb101
@@ -8040,7 +8040,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1949/05/08
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barla901
@@ -8165,7 +8165,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1949/05/08
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,gorea901
@@ -8261,7 +8261,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1949/05/09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,goetl901
@@ -8369,7 +8369,7 @@ info,hometeam,BRO
 info,site,NYC15
 info,date,1949/05/09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,conlj102
@@ -8491,7 +8491,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1949/05/09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,barrg901
@@ -8590,7 +8590,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1949/05/11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,robbs901
@@ -8695,7 +8695,7 @@ info,hometeam,BRO
 info,site,NYC15
 info,date,1949/05/11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,jordl901
@@ -8799,7 +8799,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1949/05/11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,warnl101
@@ -8902,7 +8902,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1949/05/11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,balll901
@@ -9006,7 +9006,7 @@ info,hometeam,BRO
 info,site,NYC15
 info,date,1949/05/12
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,rearb901
@@ -9123,7 +9123,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1949/05/12
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stewb901
@@ -9217,7 +9217,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1949/05/12
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barla901
@@ -9315,7 +9315,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1949/05/13
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,barrg901
@@ -9417,7 +9417,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1949/05/13
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,goetl901
@@ -9512,7 +9512,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1949/05/13
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,conlj102
@@ -9619,7 +9619,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1949/05/13
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,dascf901
@@ -9730,7 +9730,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1949/05/14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,balll901
@@ -9848,7 +9848,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1949/05/14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,warnl101
@@ -9957,7 +9957,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1949/05/14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,jordl901
@@ -10061,7 +10061,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1949/05/14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,pineb101
@@ -10167,7 +10167,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1949/05/15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barla901
@@ -10274,7 +10274,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1949/05/15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,rearb901
@@ -10376,7 +10376,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1949/05/15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stewb901
@@ -10481,7 +10481,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1949/05/15
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,gorea901
@@ -10607,7 +10607,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1949/05/15
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,robbs901
@@ -10724,7 +10724,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1949/05/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,warnl101
@@ -10845,7 +10845,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1949/05/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,dascf901
@@ -10952,7 +10952,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1949/05/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,barrg901
@@ -11054,7 +11054,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1949/05/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,goetl901
@@ -11164,7 +11164,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1949/05/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stewb901
@@ -11267,7 +11267,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1949/05/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,balll901
@@ -11368,7 +11368,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1949/05/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,jordl901
@@ -11489,7 +11489,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1949/05/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,pineb101
@@ -11591,7 +11591,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1949/05/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,gorea901
@@ -11693,7 +11693,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1949/05/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,conlj102
@@ -11786,7 +11786,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1949/05/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,rearb901
@@ -11879,7 +11879,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1949/05/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,warnl101
@@ -11974,7 +11974,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1949/05/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,goetl901
@@ -12077,7 +12077,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1949/05/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,robbs901
@@ -12174,7 +12174,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1949/05/21
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barla901
@@ -12273,7 +12273,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1949/05/21
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stewb901
@@ -12380,7 +12380,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1949/05/21
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,jordl901
@@ -12499,7 +12499,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1949/05/22
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dascf901
@@ -12622,7 +12622,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1949/05/22
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,rearb901
@@ -12720,7 +12720,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1949/05/22
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,conlj102
@@ -12815,7 +12815,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1949/05/22
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barrg901
@@ -12936,7 +12936,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1949/05/22
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,warnl101
@@ -13037,7 +13037,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1949/05/22
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,balll901
@@ -13146,7 +13146,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1949/05/23
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,goetl901
@@ -13261,7 +13261,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1949/05/24
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,rearb901
@@ -13359,7 +13359,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1949/05/24
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,barla901
@@ -13449,7 +13449,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1949/05/24
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,stewb901
@@ -13567,7 +13567,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1949/05/24
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,pineb101
@@ -13668,7 +13668,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1949/05/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barrg901
@@ -13760,7 +13760,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1949/05/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,gorea901
@@ -13875,7 +13875,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1949/05/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,conlj102
@@ -13972,7 +13972,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1949/05/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,rearb901
@@ -14074,7 +14074,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1949/05/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,warnl101
@@ -14187,7 +14187,7 @@ info,hometeam,BRO
 info,site,NYC15
 info,date,1949/05/27
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,goetl901
@@ -14279,7 +14279,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1949/05/27
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,stewb901
@@ -14384,7 +14384,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1949/05/27
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,balll901
@@ -14500,7 +14500,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1949/05/27
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,robbs901
@@ -14596,7 +14596,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1949/05/28
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barla901
@@ -14696,7 +14696,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1949/05/28
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,pineb101
@@ -14786,7 +14786,7 @@ info,hometeam,BRO
 info,site,NYC15
 info,date,1949/05/28
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,jordl901
@@ -14907,7 +14907,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1949/05/28
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,gorea901
@@ -15012,7 +15012,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1949/05/29
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,warnl101
@@ -15120,7 +15120,7 @@ info,hometeam,BRO
 info,site,NYC15
 info,date,1949/05/29
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,rearb901
@@ -15210,7 +15210,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1949/05/29
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barrg901
@@ -15332,7 +15332,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1949/05/29
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,conlj102
@@ -15432,7 +15432,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1949/05/29
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,balll901
@@ -15526,7 +15526,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1949/05/29
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,robbs901
@@ -15625,7 +15625,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1949/05/30
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dascf901
@@ -15726,7 +15726,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1949/05/30
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,pineb101
@@ -15839,7 +15839,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1949/05/30
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stewb901
@@ -15968,7 +15968,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1949/05/30
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barla901
@@ -16091,7 +16091,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1949/05/30
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,conlj102
@@ -16196,7 +16196,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1949/05/30
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barrg901
@@ -16303,7 +16303,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1949/05/30
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,goetl901
@@ -16430,7 +16430,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1949/05/30
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,gorea901
@@ -16534,7 +16534,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1949/05/31
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,balll901
@@ -16658,7 +16658,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1949/05/31
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,jordl901
@@ -16766,7 +16766,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1949/06/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,rearb901
@@ -16868,7 +16868,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1949/06/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,barla901
@@ -16981,7 +16981,7 @@ info,hometeam,BRO
 info,site,NYC15
 info,date,1949/06/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,robbs901
@@ -17101,7 +17101,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1949/06/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,warnl101
@@ -17225,7 +17225,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1949/06/02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,stewb901
@@ -17325,7 +17325,7 @@ info,hometeam,BRO
 info,site,NYC15
 info,date,1949/06/02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,pineb101
@@ -17447,7 +17447,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1949/06/02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,barrg901
@@ -17555,7 +17555,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1949/06/02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,goetl901
@@ -17653,7 +17653,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1949/06/03
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,jordl901
@@ -17752,7 +17752,7 @@ info,hometeam,BRO
 info,site,NYC15
 info,date,1949/06/03
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,gorea901
@@ -17851,7 +17851,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1949/06/03
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,balll901
@@ -17962,7 +17962,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1949/06/03
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barla901
@@ -18059,7 +18059,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1949/06/04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,conlj102
@@ -18157,7 +18157,7 @@ info,hometeam,BRO
 info,site,NYC15
 info,date,1949/06/04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,rearb901
@@ -18280,7 +18280,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1949/06/04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dascf901
@@ -18392,7 +18392,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1949/06/04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,barrg901
@@ -18487,7 +18487,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1949/06/05
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,robbs901
@@ -18588,7 +18588,7 @@ info,hometeam,BRO
 info,site,NYC15
 info,date,1949/06/05
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,goetl901
@@ -18693,7 +18693,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1949/06/05
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,balll901
@@ -18795,7 +18795,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1949/06/05
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,warnl101
@@ -18892,7 +18892,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1949/06/05
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stewb901
@@ -19006,7 +19006,7 @@ info,hometeam,BRO
 info,site,NYC15
 info,date,1949/06/06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,jordl901
@@ -19106,7 +19106,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1949/06/06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,pineb101
@@ -19218,7 +19218,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1949/06/06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barla901
@@ -19320,7 +19320,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1949/06/07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,conlj102
@@ -19408,7 +19408,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1949/06/07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,rearb901
@@ -19518,7 +19518,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1949/06/07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,gorea901
@@ -19618,7 +19618,7 @@ info,hometeam,BRO
 info,site,NYC15
 info,date,1949/06/07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barrg901
@@ -19721,7 +19721,7 @@ info,hometeam,BRO
 info,site,NYC15
 info,date,1949/06/08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,balll901
@@ -19815,7 +19815,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1949/06/08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,dascf901
@@ -19915,7 +19915,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1949/06/08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,goetl901
@@ -20038,7 +20038,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1949/06/08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,warnl101
@@ -20136,7 +20136,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1949/06/09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,jordl901
@@ -20236,7 +20236,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1949/06/09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stewb901
@@ -20336,7 +20336,7 @@ info,hometeam,BRO
 info,site,NYC15
 info,date,1949/06/09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barla901
@@ -20453,7 +20453,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1949/06/09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,robbs901
@@ -20572,7 +20572,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1949/06/10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,dascf901
@@ -20674,7 +20674,7 @@ info,hometeam,BRO
 info,site,NYC15
 info,date,1949/06/10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,conlj102
@@ -20781,7 +20781,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1949/06/10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,pineb101
@@ -20879,7 +20879,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1949/06/10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barrg901
@@ -20972,7 +20972,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1949/06/11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,gorea901
@@ -21081,7 +21081,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1949/06/11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,goetl901
@@ -21186,7 +21186,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1949/06/11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,balll901
@@ -21293,7 +21293,7 @@ info,hometeam,BRO
 info,site,NYC15
 info,date,1949/06/11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,warnl101
@@ -21402,7 +21402,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1949/06/12
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barla901
@@ -21527,7 +21527,7 @@ info,hometeam,BRO
 info,site,NYC15
 info,date,1949/06/12
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stewb901
@@ -21647,7 +21647,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1949/06/12
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,jordl901
@@ -21747,7 +21747,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1949/06/12
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,robbs901
@@ -21853,7 +21853,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1949/06/12
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,goetl901
@@ -21963,7 +21963,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1949/06/12
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,pineb101
@@ -22054,7 +22054,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1949/06/14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,gorea901
@@ -22152,7 +22152,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1949/06/14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,dascf901
@@ -22260,7 +22260,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1949/06/14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,conlj102
@@ -22367,7 +22367,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1949/06/14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,barrg901
@@ -22479,7 +22479,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1949/06/15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,goetl901
@@ -22586,7 +22586,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1949/06/15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,balll901
@@ -22693,7 +22693,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1949/06/15
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,warnl101
@@ -22785,7 +22785,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1949/06/15
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stewb901
@@ -22888,7 +22888,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1949/06/16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,jordl901
@@ -22997,7 +22997,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1949/06/16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barla901
@@ -23102,7 +23102,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1949/06/16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,warnl101
@@ -23210,7 +23210,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1949/06/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,robbs901
@@ -23314,7 +23314,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1949/06/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barrg901
@@ -23421,7 +23421,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1949/06/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,goetl901
@@ -23512,7 +23512,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1949/06/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,stewb901
@@ -23617,7 +23617,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1949/06/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,jordl901
@@ -23714,7 +23714,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1949/06/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,balll901
@@ -23813,7 +23813,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1949/06/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,pineb101
@@ -23908,7 +23908,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1949/06/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,warnl101
@@ -24022,7 +24022,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1949/06/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,gorea901
@@ -24135,7 +24135,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1949/06/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dascf901
@@ -24232,7 +24232,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1949/06/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,goetl901
@@ -24335,7 +24335,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1949/06/19
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barla901
@@ -24436,7 +24436,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1949/06/19
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barrg901
@@ -24550,7 +24550,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1949/06/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,robbs901
@@ -24644,7 +24644,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1949/06/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,jordl901
@@ -24746,7 +24746,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1949/06/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,balll901
@@ -24848,7 +24848,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1949/06/21
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,barla901
@@ -24946,7 +24946,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1949/06/21
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,pineb101
@@ -25048,7 +25048,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1949/06/21
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,conlj102
@@ -25155,7 +25155,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1949/06/21
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,goetl901
@@ -25263,7 +25263,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1949/06/22
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,warnl101
@@ -25369,7 +25369,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1949/06/22
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,gorea901
@@ -25495,7 +25495,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1949/06/22
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barrg901
@@ -25608,7 +25608,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1949/06/22
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,dascf901
@@ -25739,7 +25739,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1949/06/23
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,robbs901
@@ -25850,7 +25850,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1949/06/23
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,jordl901
@@ -25964,7 +25964,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1949/06/23
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,balll901
@@ -26064,7 +26064,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1949/06/23
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stewb901
@@ -26170,7 +26170,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1949/06/24
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barla901
@@ -26280,7 +26280,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1949/06/24
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,conlj102
@@ -26393,7 +26393,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1949/06/24
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,pineb101
@@ -26491,7 +26491,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1949/06/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,goetl901
@@ -26598,7 +26598,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1949/06/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,warnl101
@@ -26709,7 +26709,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1949/06/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barrg901
@@ -26811,7 +26811,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1949/06/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,gorea901
@@ -26926,7 +26926,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1949/06/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stewb901
@@ -27020,7 +27020,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1949/06/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,robbs901
@@ -27129,7 +27129,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1949/06/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,balll901
@@ -27232,7 +27232,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1949/06/26
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dascf901
@@ -27346,7 +27346,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1949/06/26
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,jordl901
@@ -27438,7 +27438,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1949/06/27
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,rearb901
@@ -27551,7 +27551,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1949/06/28
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,conlj102
@@ -27653,7 +27653,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1949/06/28
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,goetl901
@@ -27745,7 +27745,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1949/06/28
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,pineb101
@@ -27841,7 +27841,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1949/06/29
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,gorea901
@@ -27942,7 +27942,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1949/06/29
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,jordl901
@@ -28045,7 +28045,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1949/06/29
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barla901
@@ -28150,7 +28150,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1949/06/29
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,warnl101
@@ -28253,7 +28253,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1949/06/30
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barrg901
@@ -28344,7 +28344,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1949/06/30
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stewb901
@@ -28439,7 +28439,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1949/06/30
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,rearb901
@@ -28551,7 +28551,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1949/06/30
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,robbs901
@@ -28653,7 +28653,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1949/06/30
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dascf901
@@ -28771,7 +28771,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1949/07/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,balll901
@@ -28883,7 +28883,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1949/07/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,conlj102
@@ -28984,7 +28984,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1949/07/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,pineb101
@@ -29074,7 +29074,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1949/07/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,goetl901
@@ -29191,7 +29191,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1949/07/02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,barla901
@@ -29284,7 +29284,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1949/07/02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,warnl101
@@ -29408,7 +29408,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1949/07/02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,jordl901
@@ -29521,7 +29521,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1949/07/02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,gorea901
@@ -29625,7 +29625,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1949/07/03
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stewb901
@@ -29729,7 +29729,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1949/07/03
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,robbs901
@@ -29836,7 +29836,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1949/07/03
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,rearb901
@@ -29943,7 +29943,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1949/07/03
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barrg901
@@ -30044,7 +30044,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1949/07/04
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,goetl901
@@ -30140,7 +30140,7 @@ info,hometeam,BRO
 info,site,NYC15
 info,date,1949/07/04
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dascf901
@@ -30249,7 +30249,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1949/07/04
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,balll901
@@ -30361,7 +30361,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1949/07/04
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,conlj102
@@ -30470,7 +30470,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1949/07/04
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,warnl101
@@ -30590,7 +30590,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1949/07/04
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,jordl901
@@ -30692,7 +30692,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1949/07/04
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barla901
@@ -30789,7 +30789,7 @@ info,hometeam,BRO
 info,site,NYC15
 info,date,1949/07/04
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,pineb101
@@ -30901,7 +30901,7 @@ info,hometeam,BRO
 info,site,NYC15
 info,date,1949/07/05
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,gorea901
@@ -31005,7 +31005,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1949/07/05
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barrg901
@@ -31108,7 +31108,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1949/07/06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,balll901
@@ -31233,7 +31233,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1949/07/06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,rearb901
@@ -31336,7 +31336,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1949/07/06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,stewb901
@@ -31444,7 +31444,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1949/07/07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,robbs901
@@ -31548,7 +31548,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1949/07/07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,conlj102
@@ -31649,7 +31649,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1949/07/07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barla901
@@ -31762,7 +31762,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1949/07/07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,goetl901
@@ -31854,7 +31854,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1949/07/08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,barrg901
@@ -31946,7 +31946,7 @@ info,hometeam,BRO
 info,site,NYC15
 info,date,1949/07/08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,dascf901
@@ -32052,7 +32052,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1949/07/08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,warnl101
@@ -32164,7 +32164,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1949/07/08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,jordl901
@@ -32262,7 +32262,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1949/07/09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,rearb901
@@ -32362,7 +32362,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1949/07/09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stewb901
@@ -32468,7 +32468,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1949/07/09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,balll901
@@ -32582,7 +32582,7 @@ info,hometeam,BRO
 info,site,NYC15
 info,date,1949/07/09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,pineb101
@@ -32691,7 +32691,7 @@ info,hometeam,BRO
 info,site,NYC15
 info,date,1949/07/10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,gorea901
@@ -32804,7 +32804,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1949/07/10
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,goetl901
@@ -32899,7 +32899,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1949/07/10
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barla901
@@ -33006,7 +33006,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1949/07/10
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,jordl901
@@ -33107,7 +33107,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1949/07/10
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barrg901
@@ -33221,7 +33221,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1949/07/14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,balll901
@@ -33312,7 +33312,7 @@ info,hometeam,BRO
 info,site,NYC15
 info,date,1949/07/14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,conlj102
@@ -33426,7 +33426,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1949/07/14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,rearb901
@@ -33523,7 +33523,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1949/07/14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,robbs901
@@ -33615,7 +33615,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1949/07/15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,barla901
@@ -33712,7 +33712,7 @@ info,hometeam,BRO
 info,site,NYC15
 info,date,1949/07/15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,warnl101
@@ -33820,7 +33820,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1949/07/15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,dascf901
@@ -33916,7 +33916,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1949/07/16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barrg901
@@ -34016,7 +34016,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1949/07/16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,pineb101
@@ -34113,7 +34113,7 @@ info,hometeam,BRO
 info,site,NYC15
 info,date,1949/07/16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stewb901
@@ -34229,7 +34229,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1949/07/16
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,goetl901
@@ -34330,7 +34330,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1949/07/16
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,jordl901
@@ -34460,7 +34460,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1949/07/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,gorea901
@@ -34551,7 +34551,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1949/07/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,conlj102
@@ -34658,7 +34658,7 @@ info,hometeam,BRO
 info,site,NYC15
 info,date,1949/07/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,rearb901
@@ -34763,7 +34763,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1949/07/17
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,balll901
@@ -34865,7 +34865,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1949/07/17
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barla901
@@ -34963,7 +34963,7 @@ info,hometeam,BRO
 info,site,NYC15
 info,date,1949/07/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,goetl901
@@ -35058,7 +35058,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1949/07/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barrg901
@@ -35161,7 +35161,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1949/07/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,warnl101
@@ -35260,7 +35260,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1949/07/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,robbs901
@@ -35368,7 +35368,7 @@ info,hometeam,BRO
 info,site,NYC15
 info,date,1949/07/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,balll901
@@ -35480,7 +35480,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1949/07/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,stewb901
@@ -35576,7 +35576,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1949/07/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,jordl901
@@ -35674,7 +35674,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1949/07/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,dascf901
@@ -35781,7 +35781,7 @@ info,hometeam,BRO
 info,site,NYC15
 info,date,1949/07/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barla901
@@ -35909,7 +35909,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1949/07/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,conlj102
@@ -36014,7 +36014,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1949/07/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,rearb901
@@ -36133,7 +36133,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1949/07/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,pineb101
@@ -36233,7 +36233,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1949/07/21
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,goetl901
@@ -36332,7 +36332,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1949/07/21
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,gorea901
@@ -36437,7 +36437,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1949/07/21
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,warnl101
@@ -36537,7 +36537,7 @@ info,hometeam,BRO
 info,site,NYC15
 info,date,1949/07/21
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barrg901
@@ -36663,7 +36663,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1949/07/22
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,balll901
@@ -36770,7 +36770,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1949/07/22
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,stewb901
@@ -36878,7 +36878,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1949/07/22
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,jordl901
@@ -36974,7 +36974,7 @@ info,hometeam,BRO
 info,site,NYC15
 info,date,1949/07/22
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,robbs901
@@ -37069,7 +37069,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1949/07/23
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barla901
@@ -37178,7 +37178,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1949/07/23
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,rearb901
@@ -37280,7 +37280,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1949/07/23
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,conlj102
@@ -37405,7 +37405,7 @@ info,hometeam,BRO
 info,site,NYC15
 info,date,1949/07/23
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dascf901
@@ -37518,7 +37518,7 @@ info,hometeam,BRO
 info,site,NYC15
 info,date,1949/07/24
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,pineb101
@@ -37621,7 +37621,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1949/07/24
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,warnl101
@@ -37709,7 +37709,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1949/07/24
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barrg901
@@ -37817,7 +37817,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1949/07/24
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,goetl901
@@ -37920,7 +37920,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1949/07/24
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,jordl901
@@ -38024,7 +38024,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1949/07/24
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stewb901
@@ -38146,7 +38146,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1949/07/24
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,balll901
@@ -38249,7 +38249,7 @@ info,hometeam,BRO
 info,site,NYC15
 info,date,1949/07/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,gorea901
@@ -38387,7 +38387,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1949/07/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,conlj102
@@ -38487,7 +38487,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1949/07/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,rearb901
@@ -38586,7 +38586,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1949/07/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,robbs901
@@ -38688,7 +38688,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1949/07/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,barla901
@@ -38795,7 +38795,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1949/07/27
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dascf901
@@ -38921,7 +38921,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1949/07/27
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,barrg901
@@ -39029,7 +39029,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1949/07/27
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,goetl901
@@ -39142,7 +39142,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1949/07/27
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,warnl101
@@ -39254,7 +39254,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1949/07/28
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,jordl901
@@ -39373,7 +39373,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1949/07/28
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stewb901
@@ -39480,7 +39480,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1949/07/28
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,balll901
@@ -39585,7 +39585,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1949/07/28
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,pineb101
@@ -39692,7 +39692,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1949/07/29
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,barla901
@@ -39793,7 +39793,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1949/07/29
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,gorea901
@@ -39914,7 +39914,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1949/07/30
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,robbs901
@@ -40047,7 +40047,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1949/07/30
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barrg901
@@ -40166,7 +40166,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1949/07/30
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,rearb901
@@ -40267,7 +40267,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1949/07/30
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,goetl901
@@ -40375,7 +40375,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1949/07/31
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dascf901
@@ -40484,7 +40484,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1949/07/31
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,jordl901
@@ -40592,7 +40592,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1949/07/31
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,balll901
@@ -40702,7 +40702,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1949/07/31
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,conlj102
@@ -40809,7 +40809,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1949/07/31
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,warnl101
@@ -40921,7 +40921,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1949/07/31
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barla901
@@ -41033,7 +41033,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1949/08/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,pineb101
@@ -41138,7 +41138,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1949/08/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,rearb901
@@ -41240,7 +41240,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1949/08/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,barrg901
@@ -41337,7 +41337,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1949/08/02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,stewb901
@@ -41442,7 +41442,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1949/08/02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,goetl901
@@ -41543,7 +41543,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1949/08/02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,gorea901
@@ -41640,7 +41640,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1949/08/02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,balll901
@@ -41744,7 +41744,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1949/08/03
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,conlj102
@@ -41837,7 +41837,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1949/08/03
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,jordl901
@@ -41932,7 +41932,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1949/08/03
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barla901
@@ -42034,7 +42034,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1949/08/03
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,robbs901
@@ -42135,7 +42135,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1949/08/04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,rearb901
@@ -42248,7 +42248,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1949/08/04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dascf901
@@ -42347,7 +42347,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1949/08/04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barrg901
@@ -42453,7 +42453,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1949/08/04
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,warnl101
@@ -42559,7 +42559,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1949/08/04
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stewb901
@@ -42662,7 +42662,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1949/08/05
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,balll901
@@ -42776,7 +42776,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1949/08/05
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,pineb101
@@ -42864,7 +42864,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1949/08/05
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,goetl901
@@ -42964,7 +42964,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1949/08/05
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,conlj102
@@ -43064,7 +43064,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1949/08/06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barla901
@@ -43171,7 +43171,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1949/08/06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,warnl101
@@ -43267,7 +43267,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1949/08/06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,gorea901
@@ -43374,7 +43374,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1949/08/06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,jordl901
@@ -43474,7 +43474,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1949/08/07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stewb901
@@ -43586,7 +43586,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1949/08/07
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,robbs901
@@ -43688,7 +43688,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1949/08/07
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barrg901
@@ -43801,7 +43801,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1949/08/07
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,rearb901
@@ -43912,7 +43912,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1949/08/07
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,goetl901
@@ -44022,7 +44022,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1949/08/07
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,balll901
@@ -44123,7 +44123,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1949/08/07
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dascf901
@@ -44230,7 +44230,7 @@ info,hometeam,BRO
 info,site,NYC15
 info,date,1949/08/08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,conlj102
@@ -44335,7 +44335,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1949/08/08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,barla901
@@ -44441,7 +44441,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1949/08/09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,jordl901
@@ -44546,7 +44546,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1949/08/09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,pineb101
@@ -44650,7 +44650,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1949/08/09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,warnl101
@@ -44759,7 +44759,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1949/08/09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,barrg901
@@ -44859,7 +44859,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1949/08/10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,rearb901
@@ -44958,7 +44958,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1949/08/10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,balll901
@@ -45073,7 +45073,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1949/08/10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,gorea901
@@ -45172,7 +45172,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1949/08/10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,stewb901
@@ -45280,7 +45280,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1949/08/11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,conlj102
@@ -45404,7 +45404,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1949/08/11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,robbs901
@@ -45522,7 +45522,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1949/08/11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,goetl901
@@ -45630,7 +45630,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1949/08/12
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,warnl101
@@ -45726,7 +45726,7 @@ info,hometeam,BRO
 info,site,NYC15
 info,date,1949/08/12
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,dascf901
@@ -45826,7 +45826,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1949/08/12
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,jordl901
@@ -45928,7 +45928,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1949/08/13
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barla901
@@ -46027,7 +46027,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1949/08/13
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,rearb901
@@ -46123,7 +46123,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1949/08/14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,goetl901
@@ -46221,7 +46221,7 @@ info,hometeam,BRO
 info,site,NYC15
 info,date,1949/08/14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,pineb101
@@ -46334,7 +46334,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1949/08/14
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barrg901
@@ -46449,7 +46449,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1949/08/14
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stewb901
@@ -46548,7 +46548,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1949/08/14
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,balll901
@@ -46642,7 +46642,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1949/08/14
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,conlj102
@@ -46735,7 +46735,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1949/08/15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,goetl901
@@ -46841,7 +46841,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1949/08/15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,warnl101
@@ -46959,7 +46959,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1949/08/16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,robbs901
@@ -47070,7 +47070,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1949/08/16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,barla901
@@ -47165,7 +47165,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1949/08/16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stewb901
@@ -47256,7 +47256,7 @@ info,hometeam,BRO
 info,site,NYC15
 info,date,1949/08/16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,jordl901
@@ -47345,7 +47345,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1949/08/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,barrg901
@@ -47447,7 +47447,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1949/08/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,conlj102
@@ -47551,7 +47551,7 @@ info,hometeam,BRO
 info,site,NYC15
 info,date,1949/08/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dascf901
@@ -47673,7 +47673,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1949/08/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,pineb101
@@ -47767,7 +47767,7 @@ info,hometeam,BRO
 info,site,NYC15
 info,date,1949/08/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,goetl901
@@ -47882,7 +47882,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1949/08/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,balll901
@@ -48000,7 +48000,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1949/08/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,gorea901
@@ -48099,7 +48099,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1949/08/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,barla901
@@ -48206,7 +48206,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1949/08/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,warnl101
@@ -48315,7 +48315,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1949/08/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,rearb901
@@ -48450,7 +48450,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1949/08/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barrg901
@@ -48557,7 +48557,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1949/08/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,jordl901
@@ -48651,7 +48651,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1949/08/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stewb901
@@ -48769,7 +48769,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1949/08/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,robbs901
@@ -48875,7 +48875,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1949/08/21
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dascf901
@@ -48970,7 +48970,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1949/08/21
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,conlj102
@@ -49070,7 +49070,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1949/08/21
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,balll901
@@ -49169,7 +49169,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1949/08/21
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,pineb101
@@ -49266,7 +49266,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1949/08/21
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,warnl101
@@ -49367,7 +49367,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1949/08/21
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,gorea901
@@ -49463,7 +49463,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1949/08/21
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barla901
@@ -49558,7 +49558,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1949/08/22
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,goetl901
@@ -49673,7 +49673,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1949/08/23
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,barrg901
@@ -49775,7 +49775,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1949/08/23
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,robbs901
@@ -49886,7 +49886,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1949/08/23
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,rearb901
@@ -50004,7 +50004,7 @@ info,hometeam,BRO
 info,site,NYC15
 info,date,1949/08/23
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stewb901
@@ -50115,7 +50115,7 @@ info,hometeam,BRO
 info,site,NYC15
 info,date,1949/08/23
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,conlj102
@@ -50206,7 +50206,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1949/08/24
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,pineb101
@@ -50304,7 +50304,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1949/08/24
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,balll901
@@ -50410,7 +50410,7 @@ info,hometeam,BRO
 info,site,NYC15
 info,date,1949/08/24
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dascf901
@@ -50513,7 +50513,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1949/08/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,warnl101
@@ -50614,7 +50614,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1949/08/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,jordl901
@@ -50710,7 +50710,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1949/08/25
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,gorea901
@@ -50806,7 +50806,7 @@ info,hometeam,BRO
 info,site,NYC15
 info,date,1949/08/25
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barla901
@@ -50909,7 +50909,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1949/08/25
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,robbs901
@@ -51014,7 +51014,7 @@ info,hometeam,BRO
 info,site,NYC15
 info,date,1949/08/25
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barrg901
@@ -51119,7 +51119,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1949/08/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,goetl901
@@ -51223,7 +51223,7 @@ info,hometeam,BRO
 info,site,NYC15
 info,date,1949/08/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,balll901
@@ -51336,7 +51336,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1949/08/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,pineb101
@@ -51434,7 +51434,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1949/08/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,stewb901
@@ -51539,7 +51539,7 @@ info,hometeam,BRO
 info,site,NYC15
 info,date,1949/08/27
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barla901
@@ -51636,7 +51636,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1949/08/27
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,conlj102
@@ -51748,7 +51748,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1949/08/27
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dascf901
@@ -51853,7 +51853,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1949/08/27
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,rearb901
@@ -51951,7 +51951,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1949/08/27
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,jordl901
@@ -52064,7 +52064,7 @@ info,hometeam,BRO
 info,site,NYC15
 info,date,1949/08/28
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,goetl901
@@ -52167,7 +52167,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1949/08/28
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,gorea901
@@ -52275,7 +52275,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1949/08/28
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,warnl101
@@ -52378,7 +52378,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1949/08/28
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barrg901
@@ -52481,7 +52481,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1949/08/28
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stewb901
@@ -52587,7 +52587,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1949/08/28
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,balll901
@@ -52688,7 +52688,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1949/08/28
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,robbs901
@@ -52784,7 +52784,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1949/08/29
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,conlj102
@@ -52895,7 +52895,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1949/08/29
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,pineb101
@@ -52993,7 +52993,7 @@ info,hometeam,BRO
 info,site,NYC15
 info,date,1949/08/29
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,rearb901
@@ -53087,7 +53087,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1949/08/29
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,barla901
@@ -53186,7 +53186,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1949/08/30
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dascf901
@@ -53299,7 +53299,7 @@ info,hometeam,BRO
 info,site,NYC15
 info,date,1949/08/30
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,jordl901
@@ -53390,7 +53390,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1949/08/31
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,warnl101
@@ -53497,7 +53497,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1949/08/31
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,goetl901
@@ -53606,7 +53606,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1949/09/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stewb901
@@ -53728,7 +53728,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1949/09/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,rearb901
@@ -53831,7 +53831,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1949/09/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,barrg901
@@ -53924,7 +53924,7 @@ info,hometeam,BRO
 info,site,NYC15
 info,date,1949/09/01
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,gorea901
@@ -54043,7 +54043,7 @@ info,hometeam,BRO
 info,site,NYC15
 info,date,1949/09/01
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,robbs901
@@ -54158,7 +54158,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1949/09/02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,pineb101
@@ -54259,7 +54259,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1949/09/02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,conlj102
@@ -54358,7 +54358,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1949/09/03
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barla901
@@ -54478,7 +54478,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1949/09/03
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,jordl901
@@ -54613,7 +54613,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1949/09/03
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,warnl101
@@ -54721,7 +54721,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1949/09/03
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,gorea901
@@ -54827,7 +54827,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1949/09/04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dascf901
@@ -54933,7 +54933,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1949/09/04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,robbs901
@@ -55044,7 +55044,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1949/09/04
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,goetl901
@@ -55142,7 +55142,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1949/09/04
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stewb901
@@ -55261,7 +55261,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1949/09/04
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,rearb901
@@ -55367,7 +55367,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1949/09/04
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,conlj102
@@ -55478,7 +55478,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1949/09/05
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,jordl901
@@ -55586,7 +55586,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1949/09/05
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,warnl101
@@ -55694,7 +55694,7 @@ info,hometeam,BRO
 info,site,NYC15
 info,date,1949/09/05
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,pineb101
@@ -55809,7 +55809,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1949/09/05
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barrg901
@@ -55904,7 +55904,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1949/09/05
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barla901
@@ -56005,7 +56005,7 @@ info,hometeam,BRO
 info,site,NYC15
 info,date,1949/09/05
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,gorea901
@@ -56105,7 +56105,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1949/09/05
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stewb901
@@ -56197,7 +56197,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1949/09/05
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,goetl901
@@ -56315,7 +56315,7 @@ info,hometeam,BRO
 info,site,NYC15
 info,date,1949/09/06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,robbs901
@@ -56413,7 +56413,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1949/09/06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,dascf901
@@ -56520,7 +56520,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1949/09/06
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,conlj102
@@ -56623,7 +56623,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1949/09/06
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,warnl101
@@ -56718,7 +56718,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1949/09/07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,rearb901
@@ -56814,7 +56814,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1949/09/07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,barrg901
@@ -56913,7 +56913,7 @@ info,hometeam,BRO
 info,site,NYC15
 info,date,1949/09/07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,pineb101
@@ -57037,7 +57037,7 @@ info,hometeam,BRO
 info,site,NYC15
 info,date,1949/09/08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,stewb901
@@ -57150,7 +57150,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1949/09/08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,gorea901
@@ -57241,7 +57241,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1949/09/08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barla901
@@ -57340,7 +57340,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1949/09/08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,jordl901
@@ -57444,7 +57444,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1949/09/09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,dascf901
@@ -57550,7 +57550,7 @@ info,hometeam,BRO
 info,site,NYC15
 info,date,1949/09/09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,conlj102
@@ -57655,7 +57655,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1949/09/09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,goetl901
@@ -57752,7 +57752,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1949/09/10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,robbs901
@@ -57846,7 +57846,7 @@ info,hometeam,BRO
 info,site,NYC15
 info,date,1949/09/10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,warnl101
@@ -57943,7 +57943,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1949/09/10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barrg901
@@ -58056,7 +58056,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1949/09/10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,rearb901
@@ -58170,7 +58170,7 @@ info,hometeam,BRO
 info,site,NYC15
 info,date,1949/09/11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stewb901
@@ -58290,7 +58290,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1949/09/11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,jordl901
@@ -58388,7 +58388,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1949/09/11
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barla901
@@ -58506,7 +58506,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1949/09/11
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,pineb101
@@ -58605,7 +58605,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1949/09/11
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,balll901
@@ -58706,7 +58706,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1949/09/11
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,gorea901
@@ -58812,7 +58812,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1949/09/13
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,warnl101
@@ -58928,7 +58928,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1949/09/13
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,robbs901
@@ -59029,7 +59029,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1949/09/13
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,goetl901
@@ -59121,7 +59121,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1949/09/14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,jordl901
@@ -59231,7 +59231,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1949/09/14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dascf901
@@ -59345,7 +59345,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1949/09/14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stewb901
@@ -59459,7 +59459,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1949/09/14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,pineb101
@@ -59561,7 +59561,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1949/09/16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,conlj102
@@ -59671,7 +59671,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1949/09/16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,boggd901
@@ -59772,7 +59772,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1949/09/16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,barrg901
@@ -59882,7 +59882,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1949/09/16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,gorea901
@@ -59992,7 +59992,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1949/09/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barla901
@@ -60091,7 +60091,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1949/09/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,goetl901
@@ -60180,7 +60180,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1949/09/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,warnl101
@@ -60278,7 +60278,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1949/09/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,robbs901
@@ -60382,7 +60382,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1949/09/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barrg901
@@ -60504,7 +60504,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1949/09/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,pineb101
@@ -60603,7 +60603,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1949/09/18
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stewb901
@@ -60715,7 +60715,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1949/09/18
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,rearb901
@@ -60829,7 +60829,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1949/09/18
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,conlj102
@@ -60925,7 +60925,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1949/09/18
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,jordl901
@@ -61039,7 +61039,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1949/09/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dascf901
@@ -61137,7 +61137,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1949/09/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,warnl101
@@ -61241,7 +61241,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1949/09/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,goetl901
@@ -61349,7 +61349,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1949/09/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,barla901
@@ -61453,7 +61453,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1949/09/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,rearb901
@@ -61546,7 +61546,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1949/09/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,boggd901
@@ -61654,7 +61654,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1949/09/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,gorea901
@@ -61758,7 +61758,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1949/09/21
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,pineb101
@@ -61864,7 +61864,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1949/09/21
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,jordl901
@@ -61958,7 +61958,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1949/09/21
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barrg901
@@ -62067,7 +62067,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1949/09/21
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stewb901
@@ -62157,7 +62157,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1949/09/21
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,conlj102
@@ -62259,7 +62259,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1949/09/21
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,goetl901
@@ -62361,7 +62361,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1949/09/21
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barla901
@@ -62462,7 +62462,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1949/09/22
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,pineb101
@@ -62575,7 +62575,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1949/09/22
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,rearb901
@@ -62675,7 +62675,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1949/09/22
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,warnl101
@@ -62794,7 +62794,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1949/09/22
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barrg901
@@ -62904,7 +62904,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1949/09/22
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barla901
@@ -63014,7 +63014,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1949/09/24
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,stewb901
@@ -63125,7 +63125,7 @@ info,hometeam,BRO
 info,site,NYC15
 info,date,1949/09/24
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,jordl901
@@ -63234,7 +63234,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1949/09/24
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barrg901
@@ -63342,7 +63342,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1949/09/24
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,gorea901
@@ -63449,7 +63449,7 @@ info,hometeam,BRO
 info,site,NYC15
 info,date,1949/09/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,goetl901
@@ -63559,7 +63559,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1949/09/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,conlj102
@@ -63659,7 +63659,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1949/09/25
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,robbs901
@@ -63762,7 +63762,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1949/09/25
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barla901
@@ -63853,7 +63853,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1949/09/25
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barrg901
@@ -63964,7 +63964,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1949/09/25
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,pineb101
@@ -64071,7 +64071,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1949/09/27
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,gorea901
@@ -64182,7 +64182,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1949/09/27
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,warnl101
@@ -64290,7 +64290,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1949/09/28
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,rearb901
@@ -64389,7 +64389,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1949/09/29
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,robbs901
@@ -64491,7 +64491,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1949/09/29
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barla901
@@ -64598,7 +64598,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1949/09/29
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barrg901
@@ -64699,7 +64699,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1949/09/30
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,stewb901
@@ -64790,7 +64790,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1949/09/30
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,pineb101
@@ -64899,7 +64899,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1949/10/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,jordl901
@@ -65024,7 +65024,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1949/10/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,boggd901
@@ -65118,7 +65118,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1949/10/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dascf901
@@ -65214,7 +65214,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1949/10/02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,goetl901
@@ -65343,7 +65343,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1949/10/02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barrg901
@@ -65439,7 +65439,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1949/10/02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,gorea901
@@ -65565,7 +65565,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1949/10/02
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,conlj102
@@ -65669,7 +65669,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1949/10/02
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,warnl101

--- a/event/regular/1949.EDA
+++ b/event/regular/1949.EDA
@@ -13115,7 +13115,7 @@ info,hometeam,WS1
 info,site,WAS09
 info,date,1949/10/02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,papaj901

--- a/event/regular/1950.EBA
+++ b/event/regular/1950.EBA
@@ -5,7 +5,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1950/04/19
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mckib901
@@ -108,7 +108,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1950/07/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,passa901
@@ -230,7 +230,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1950/08/15
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,papaj901
@@ -335,7 +335,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1950/08/16
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,papaj901
@@ -441,7 +441,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1950/09/27
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,papaj901
@@ -552,7 +552,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1950/04/30
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,boyej901
@@ -675,7 +675,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1950/06/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,berrc103
@@ -771,7 +771,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1950/06/23
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,berrc103
@@ -887,7 +887,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1950/06/30
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,hurle901
@@ -994,7 +994,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1950/07/02
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hurle901
@@ -1126,7 +1126,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1950/07/04
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mcgob901
@@ -1221,7 +1221,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1950/07/04
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stevj901
@@ -1340,7 +1340,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1950/07/30
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,boyej901
@@ -1465,7 +1465,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1950/08/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,mcgob901
@@ -1560,7 +1560,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1950/08/06
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hurle901
@@ -1659,7 +1659,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1950/08/08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,boyej901
@@ -1771,7 +1771,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1950/08/10
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stevj901
@@ -1865,7 +1865,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1950/09/06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,hurle901
@@ -1969,7 +1969,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1950/09/07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,soarh901
@@ -2075,7 +2075,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1950/09/08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,mcgob901
@@ -2170,7 +2170,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1950/09/10
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mcgob901
@@ -2276,7 +2276,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1950/09/12
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,stevj901
@@ -2372,7 +2372,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1950/09/14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,summb901
@@ -2472,7 +2472,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1950/09/15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,soarh901
@@ -2581,7 +2581,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1950/09/16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stevj901
@@ -2678,7 +2678,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1950/09/17
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,soarh901
@@ -2777,7 +2777,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1950/09/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,mckib901
@@ -2880,7 +2880,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1950/09/30
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,honoj901
@@ -2979,7 +2979,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1950/10/01
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,honoj901
@@ -3094,7 +3094,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1950/05/14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,romme101
@@ -3206,7 +3206,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1950/05/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,grieb901
@@ -3310,7 +3310,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1950/06/13
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,mckib901
@@ -3410,7 +3410,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1950/06/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mckib901
@@ -3504,7 +3504,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1950/06/21
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,romme101
@@ -3604,7 +3604,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1950/06/27
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,mckib901
@@ -3700,7 +3700,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1950/07/30
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,papaj901
@@ -3812,7 +3812,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1950/08/20
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,passa901
@@ -3923,7 +3923,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1950/09/03
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,soarh901
@@ -4022,7 +4022,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1950/09/04
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,papaj901
@@ -4133,7 +4133,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1950/09/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hubbc901
@@ -4230,7 +4230,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1950/09/26
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,grieb901
@@ -4343,7 +4343,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1950/09/28
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stevj901
@@ -4454,7 +4454,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1950/06/16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,mckib901
@@ -4548,7 +4548,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1950/09/15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,berrc103
@@ -4664,7 +4664,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1950/05/30
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,summb901
@@ -4764,7 +4764,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1950/06/10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mcgob901
@@ -4872,7 +4872,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1950/07/09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,romme101
@@ -4978,7 +4978,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1950/07/19
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stevj901
@@ -5092,7 +5092,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1950/08/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,soarh901
@@ -5204,7 +5204,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1950/04/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hubbc901
@@ -5313,7 +5313,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1950/06/03
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,summb901
@@ -5410,7 +5410,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1950/06/06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,summb901
@@ -5524,7 +5524,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1950/06/07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,passa901
@@ -5628,7 +5628,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1950/06/09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,soarh901
@@ -5722,7 +5722,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1950/07/14
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,mcgob901
@@ -5816,7 +5816,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1950/07/14
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,honoj901
@@ -5919,7 +5919,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1950/07/21
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,romme101
@@ -6036,7 +6036,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1950/08/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,hubbc901
@@ -6130,7 +6130,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1950/08/20
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hubbc901
@@ -6235,7 +6235,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1950/08/23
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,berrc103
@@ -6329,7 +6329,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1950/08/23
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,passa901
@@ -6434,7 +6434,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1950/08/30
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,papaj901
@@ -6531,7 +6531,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1950/08/30
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,stevj901
@@ -6649,7 +6649,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1950/08/31
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,hubbc901
@@ -6743,7 +6743,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1950/08/31
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,papaj901
@@ -6833,7 +6833,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1950/09/02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,grieb901
@@ -6934,7 +6934,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1950/10/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mckib901
@@ -7036,7 +7036,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1950/09/25
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,passa901
@@ -7133,7 +7133,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1950/09/28
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mcgob901
@@ -7246,7 +7246,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1950/04/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,stevj901
@@ -7356,7 +7356,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1950/04/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,summb901
@@ -7483,7 +7483,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1950/05/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,honoj901
@@ -7627,7 +7627,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1950/05/21
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,papaj901
@@ -7730,7 +7730,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1950/05/21
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,papaj901
@@ -7835,7 +7835,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1950/05/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,mcgob901
@@ -7935,7 +7935,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1950/05/27
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,honoj901
@@ -8043,7 +8043,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1950/05/28
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mckib901
@@ -8133,7 +8133,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1950/05/28
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hurle901
@@ -8234,7 +8234,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1950/05/30
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hubbc901
@@ -8372,7 +8372,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1950/06/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,berrc103
@@ -8479,7 +8479,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1950/06/18
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,boyej901
@@ -8602,7 +8602,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1950/06/18
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,passa901
@@ -8706,7 +8706,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1950/06/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,grieb901
@@ -8795,7 +8795,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1950/06/21
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,stevj901
@@ -8902,7 +8902,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1950/06/23
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,grieb901
@@ -9011,7 +9011,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1950/06/24
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stevj901
@@ -9115,7 +9115,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1950/06/25
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,grieb901
@@ -9219,7 +9219,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1950/07/07
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,stevj901
@@ -9320,7 +9320,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1950/07/08
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,hubbc901
@@ -9445,7 +9445,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1950/07/08
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,papaj901
@@ -9555,7 +9555,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1950/07/27
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,mckib901
@@ -9650,7 +9650,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1950/08/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,summb901
@@ -9745,7 +9745,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1950/08/02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,grieb901
@@ -9857,7 +9857,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1950/08/04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,boyej901
@@ -9975,7 +9975,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1950/08/05
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,summb901
@@ -10066,7 +10066,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1950/08/06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,grieb901
@@ -10169,7 +10169,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1950/08/11
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,passa901
@@ -10266,7 +10266,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1950/08/11
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,summb901
@@ -10371,7 +10371,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1950/09/12
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,romme101
@@ -10466,7 +10466,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1950/09/13
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,papaj901
@@ -10563,7 +10563,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1950/09/17
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,summb901
@@ -10675,7 +10675,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1950/09/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,summb901
@@ -10777,7 +10777,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1950/09/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,soarh901
@@ -10885,7 +10885,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1950/09/23
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hurle901
@@ -10991,7 +10991,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1950/09/24
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,honoj901
@@ -11088,7 +11088,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1950/09/14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,honoj901
@@ -11189,7 +11189,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1950/07/09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stevj901
@@ -11282,7 +11282,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1950/07/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mckib901
@@ -11381,7 +11381,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1950/07/03
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mckib901
@@ -11495,7 +11495,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1950/07/29
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,summb901
@@ -11614,7 +11614,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1950/09/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hurle901

--- a/event/regular/1950.EBN
+++ b/event/regular/1950.EBN
@@ -5,7 +5,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1950/07/07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,conlj102
@@ -105,7 +105,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1950/07/09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stewb901
@@ -208,7 +208,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1950/07/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,goetl901
@@ -323,7 +323,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1950/08/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,conlj102
@@ -414,7 +414,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1950/08/02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,gorea901
@@ -506,7 +506,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1950/08/06
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,warnl101
@@ -620,7 +620,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1950/08/07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,barla901
@@ -722,7 +722,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1950/08/08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,donaa901
@@ -815,7 +815,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1950/09/12
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,stewb901
@@ -913,7 +913,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1950/09/15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,barla901
@@ -1016,7 +1016,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1950/09/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,dascf901
@@ -1142,7 +1142,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1950/09/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,jordl901
@@ -1237,7 +1237,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1950/05/07
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,goetl901
@@ -1340,7 +1340,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1950/05/14
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,balll901
@@ -1468,7 +1468,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1950/08/20
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,donaa901
@@ -1568,7 +1568,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1950/08/20
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,balll901
@@ -1667,7 +1667,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1950/08/24
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,boggd901
@@ -1764,7 +1764,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1950/09/27
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,gorea901
@@ -1878,7 +1878,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1950/07/23
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dascf901
@@ -1970,7 +1970,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1950/07/28
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,donaa901
@@ -2075,7 +2075,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1950/08/05
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,jordl901
@@ -2179,7 +2179,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1950/09/30
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,warnl101
@@ -2277,7 +2277,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1950/10/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,balll901
@@ -2394,7 +2394,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1950/07/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,warnl101
@@ -2499,7 +2499,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1950/05/05
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,donaa901
@@ -2610,7 +2610,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1950/05/06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,balll901
@@ -2746,7 +2746,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1950/05/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,pineb101
@@ -2842,7 +2842,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1950/05/28
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,warnl101
@@ -2946,7 +2946,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1950/05/30
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,boggd901
@@ -3074,7 +3074,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1950/06/02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,barla901
@@ -3173,7 +3173,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1950/06/04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dascf901
@@ -3289,7 +3289,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1950/07/09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,balll901
@@ -3395,7 +3395,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1950/07/15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,boggd901
@@ -3499,7 +3499,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1950/07/16
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,gorea901
@@ -3608,7 +3608,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1950/07/16
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,conlj102
@@ -3716,7 +3716,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1950/07/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,stewb901
@@ -3823,7 +3823,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1950/08/08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,conlj102
@@ -3935,7 +3935,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1950/08/10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,gorea901
@@ -4044,7 +4044,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1950/08/11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,robbs901
@@ -4150,7 +4150,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1950/08/13
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,robbs901
@@ -4245,7 +4245,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1950/08/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,jordl901
@@ -4355,7 +4355,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1950/08/27
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,balll901
@@ -4474,7 +4474,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1950/08/27
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,warnl101
@@ -4577,7 +4577,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1950/08/29
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,barla901
@@ -4689,7 +4689,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1950/08/30
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,donaa901
@@ -4788,7 +4788,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1950/09/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,warnl101
@@ -4897,7 +4897,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1950/09/02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barla901
@@ -5003,7 +5003,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1950/04/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,jordl901
@@ -5101,7 +5101,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1950/05/04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,dascf901
@@ -5221,7 +5221,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1950/05/06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,jordl901
@@ -5343,7 +5343,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1950/05/07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,pineb101
@@ -5456,7 +5456,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1950/06/11
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dascf901
@@ -5552,7 +5552,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1950/06/11
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,jordl901
@@ -5659,7 +5659,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1950/06/30
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,donaa901
@@ -5762,7 +5762,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1950/07/02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barla901
@@ -5872,7 +5872,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1950/07/04
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,jordl901
@@ -5965,7 +5965,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1950/07/13
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,barla901
@@ -6064,7 +6064,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1950/07/14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,donaa901
@@ -6168,7 +6168,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1950/07/15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,balll901
@@ -6279,7 +6279,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1950/07/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,gorea901
@@ -6393,7 +6393,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1950/08/16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,robbs901
@@ -6502,7 +6502,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1950/08/23
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,donaa901
@@ -6597,7 +6597,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1950/08/24
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,conlj102
@@ -6720,7 +6720,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1950/09/05
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,goetl901
@@ -6819,7 +6819,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1950/09/06
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dascf901
@@ -6932,7 +6932,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1950/09/06
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,jordl901
@@ -7026,7 +7026,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1950/09/07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,goetl901
@@ -7128,7 +7128,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1950/09/29
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,boggd901
@@ -7236,7 +7236,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1950/09/30
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,robbs901
@@ -7332,7 +7332,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1950/09/30
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,pineb101
@@ -7422,7 +7422,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1950/10/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,boggd901
@@ -7542,7 +7542,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1950/07/22
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,gorea901
@@ -7646,7 +7646,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1950/07/29
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,warnl101
@@ -7755,7 +7755,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1950/07/08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,warnl101
@@ -7849,7 +7849,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1950/04/30
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,goetl901

--- a/event/regular/1951.EBA
+++ b/event/regular/1951.EBA
@@ -5,7 +5,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1951/05/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,grieb901
@@ -110,7 +110,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1951/05/27
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,summb901
@@ -206,7 +206,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1951/05/27
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,grieb901
@@ -314,7 +314,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1951/07/04
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,berrc103
@@ -421,7 +421,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1951/07/04
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,nappl901
@@ -534,7 +534,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1951/07/15
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,summb901
@@ -635,7 +635,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1951/07/15
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,duffj901
@@ -746,7 +746,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1951/08/06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,berrc103
@@ -853,7 +853,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1951/08/08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,passa901
@@ -968,7 +968,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1951/08/10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,hurle901
@@ -1070,7 +1070,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1951/08/11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,passa901
@@ -1179,7 +1179,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1951/08/12
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,berrc103
@@ -1273,7 +1273,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1951/08/21
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,berrc103
@@ -1378,7 +1378,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1951/08/23
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,nappl901
@@ -1471,7 +1471,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1951/08/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,romme101
@@ -1579,7 +1579,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1951/08/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hubbc901
@@ -1671,7 +1671,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1951/08/27
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,soarh901
@@ -1766,7 +1766,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1951/09/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,romme101
@@ -1868,7 +1868,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1951/09/02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,duffj901
@@ -1964,7 +1964,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1951/09/03
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mcgob901
@@ -2080,7 +2080,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1951/09/03
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,soarh901
@@ -2181,7 +2181,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1951/05/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stevj901
@@ -2279,7 +2279,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1951/07/16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,grieb901
@@ -2391,7 +2391,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1951/07/19
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,nappl901
@@ -2490,7 +2490,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1951/08/09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,berrc103
@@ -2598,7 +2598,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1951/08/20
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,romme101
@@ -2691,7 +2691,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1951/06/19
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,grieb901
@@ -2807,7 +2807,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1951/05/15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,mcgob901
@@ -2929,7 +2929,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1951/06/24
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hubbc901
@@ -3027,7 +3027,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1951/06/24
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,romme101
@@ -3129,7 +3129,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1951/07/31
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,hurle901
@@ -3238,7 +3238,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1951/09/05
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,honoj901
@@ -3335,7 +3335,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1951/05/09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,berrc103
@@ -3442,7 +3442,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1951/05/11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,mcgob901
@@ -3540,7 +3540,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1951/05/13
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mckib901
@@ -3653,7 +3653,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1951/05/13
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,honoj901
@@ -3757,7 +3757,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1951/06/05
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,passa901
@@ -3858,7 +3858,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1951/06/06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,summb901
@@ -3972,7 +3972,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1951/07/06
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,soarh901
@@ -4082,7 +4082,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1951/07/06
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,honoj901
@@ -4181,7 +4181,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1951/07/07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,hubbc901
@@ -4280,7 +4280,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1951/07/12
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,passa901
@@ -4393,7 +4393,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1951/07/12
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,berrc103
@@ -4490,7 +4490,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1951/07/13
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,nappl901
@@ -4592,7 +4592,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1951/07/14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,passa901
@@ -4701,7 +4701,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1951/07/17
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,hubbc901
@@ -4801,7 +4801,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1951/07/17
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,papaj901
@@ -4897,7 +4897,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1951/07/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,duffj901
@@ -4992,7 +4992,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1951/07/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,hubbc901
@@ -5100,7 +5100,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1951/07/21
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,duffj901
@@ -5200,7 +5200,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1951/08/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,hurle901
@@ -5301,7 +5301,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1951/08/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,passa901
@@ -5416,7 +5416,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1951/08/19
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,papaj901
@@ -5510,7 +5510,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1951/08/19
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hurle901
@@ -5619,7 +5619,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1951/08/24
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,summb901
@@ -5715,7 +5715,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1951/08/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,grieb901
@@ -5831,7 +5831,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1951/08/26
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,papaj901
@@ -5933,7 +5933,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1951/08/26
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,duffj901
@@ -6035,7 +6035,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1951/09/06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,romme101
@@ -6144,7 +6144,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1951/09/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,nappl901
@@ -6238,7 +6238,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1951/09/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,grieb901
@@ -6339,7 +6339,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1951/09/27
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,soarh901
@@ -6435,7 +6435,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1951/09/28
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,nappl901
@@ -6535,7 +6535,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1951/09/28
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,grieb901
@@ -6644,7 +6644,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1951/09/29
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,soarh901
@@ -6747,7 +6747,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1951/04/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hubbc901

--- a/event/regular/1951.EBN
+++ b/event/regular/1951.EBN
@@ -5,7 +5,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1951/07/05
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,jordl901
@@ -105,7 +105,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1951/09/03
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dascf901
@@ -198,7 +198,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1951/09/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,jordl901
@@ -311,7 +311,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1951/09/29
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,pineb101
@@ -421,7 +421,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1951/09/30
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,robbs901
@@ -532,7 +532,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1951/09/30
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,pineb101
@@ -627,7 +627,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1951/04/24
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dascf901
@@ -734,7 +734,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1951/06/23
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,boggd901
@@ -847,7 +847,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1951/06/02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,balll901
@@ -957,7 +957,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1951/07/02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,donaa901
@@ -1061,7 +1061,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1951/08/21
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,goetl901
@@ -1161,7 +1161,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1951/07/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,barla901
@@ -1263,7 +1263,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1951/08/24
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,boggd901
@@ -1362,7 +1362,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1951/08/28
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,balll901
@@ -1456,7 +1456,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1951/08/30
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,donaa901
@@ -1566,7 +1566,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1951/05/11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,barla901
@@ -1686,7 +1686,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1951/05/13
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,balll901
@@ -1787,7 +1787,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1951/05/15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,conlj102
@@ -1903,7 +1903,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1951/05/16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,gorea901
@@ -2005,7 +2005,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1951/06/15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,conlj102
@@ -2108,7 +2108,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1951/06/17
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,gorea901
@@ -2228,7 +2228,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1951/06/17
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,conlj102
@@ -2361,7 +2361,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1951/07/02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,stewb901
@@ -2466,7 +2466,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1951/07/08
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,jordl901
@@ -2570,7 +2570,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1951/07/08
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dascf901
@@ -2700,7 +2700,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1951/08/04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barla901
@@ -2797,7 +2797,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1951/08/05
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,balll901
@@ -2930,7 +2930,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1951/08/15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,donaa901
@@ -3023,7 +3023,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1951/08/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,boggd901
@@ -3122,7 +3122,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1951/09/07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,jordl901
@@ -3229,7 +3229,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1951/09/11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,robbs901
@@ -3329,7 +3329,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1951/09/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,balll901
@@ -3432,7 +3432,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1951/08/16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,balll901
@@ -3547,7 +3547,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1951/09/08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,warnl101
@@ -3642,7 +3642,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1951/04/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,dascf901
@@ -3747,7 +3747,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1951/04/22
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,goetl901
@@ -3865,7 +3865,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1951/04/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,stewb901
@@ -3964,7 +3964,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1951/05/16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,balll901
@@ -4068,7 +4068,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1951/05/28
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,warnl101
@@ -4184,7 +4184,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1951/05/30
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,pineb101
@@ -4290,7 +4290,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1951/06/15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,barla901
@@ -4402,7 +4402,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1951/06/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,jordl901
@@ -4494,7 +4494,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1951/06/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,dascf901
@@ -4616,7 +4616,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1951/06/29
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,jordl901
@@ -4732,7 +4732,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1951/07/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,conlj102
@@ -4842,7 +4842,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1951/07/24
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,stewb901
@@ -4964,7 +4964,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1951/08/07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,barla901
@@ -5088,7 +5088,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1951/08/08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,donaa901
@@ -5200,7 +5200,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1951/08/13
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,balll901
@@ -5304,7 +5304,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1951/08/14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,barla901
@@ -5408,7 +5408,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1951/09/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,dascf901
@@ -5510,7 +5510,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1951/09/02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stewb901
@@ -5613,7 +5613,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1951/09/16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,pineb101
@@ -5723,7 +5723,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1951/09/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,boggd901
@@ -5821,7 +5821,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1951/09/22
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,balll901
@@ -5943,7 +5943,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1951/09/23
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,gormt101
@@ -6046,7 +6046,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1951/09/23
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barla901
@@ -6154,7 +6154,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1951/06/21
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dascf901
@@ -6250,7 +6250,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1951/05/21
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,warnl101

--- a/event/regular/1951CHN.EVN
+++ b/event/regular/1951CHN.EVN
@@ -3486,7 +3486,7 @@ info,hometeam,CHN
 info,date,1951/06/18
 info,site,CHI11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barla901

--- a/event/regular/1951NY1.EVN
+++ b/event/regular/1951NY1.EVN
@@ -466,7 +466,7 @@ info,hometeam,NY1
 info,date,1951/04/26
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,pineb101
@@ -601,7 +601,7 @@ info,hometeam,NY1
 info,date,1951/04/27
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,boggd901
@@ -737,7 +737,7 @@ info,hometeam,NY1
 info,date,1951/05/01
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,dascf901
@@ -1011,7 +1011,7 @@ info,hometeam,NY1
 info,date,1951/05/03
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,warnl101
@@ -1484,7 +1484,7 @@ info,hometeam,NY1
 info,date,1951/05/06
 info,site,NYC14
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,donaa901
@@ -1644,7 +1644,7 @@ info,hometeam,NY1
 info,date,1951/05/06
 info,site,NYC14
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,balll901
@@ -1799,7 +1799,7 @@ info,hometeam,NY1
 info,date,1951/05/08
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,gorea901
@@ -1943,7 +1943,7 @@ info,hometeam,NY1
 info,date,1951/05/09
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stewb901
@@ -2111,7 +2111,7 @@ info,hometeam,NY1
 info,date,1951/05/10
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,conlj102
@@ -2573,7 +2573,7 @@ info,hometeam,NY1
 info,date,1951/05/13
 info,site,NYC14
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dascf901
@@ -2706,7 +2706,7 @@ info,hometeam,NY1
 info,date,1951/05/28
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,goetl901
@@ -3150,7 +3150,7 @@ info,hometeam,NY1
 info,date,1951/06/01
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,donaa901
@@ -3288,7 +3288,7 @@ info,hometeam,NY1
 info,date,1951/06/03
 info,site,NYC14
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barla901
@@ -3398,7 +3398,7 @@ info,hometeam,NY1
 info,date,1951/06/03
 info,site,NYC14
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,donaa901
@@ -3695,7 +3695,7 @@ info,hometeam,NY1
 info,date,1951/06/05
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,goetl901
@@ -4285,7 +4285,7 @@ info,hometeam,NY1
 info,date,1951/06/10
 info,site,NYC14
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stewb901
@@ -4415,7 +4415,7 @@ info,hometeam,NY1
 info,date,1951/06/10
 info,site,NYC14
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,gorea901
@@ -7928,7 +7928,7 @@ info,hometeam,NY1
 info,date,1951/08/13
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,conlj102
@@ -8892,7 +8892,7 @@ info,hometeam,NY1
 info,date,1951/08/26
 info,site,NYC14
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,donaa901
@@ -9035,7 +9035,7 @@ info,hometeam,NY1
 info,date,1951/08/26
 info,site,NYC14
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,balll901
@@ -9622,7 +9622,7 @@ info,hometeam,NY1
 info,date,1951/08/29
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stewb901
@@ -10215,7 +10215,7 @@ info,hometeam,NY1
 info,date,1951/09/03
 info,site,NYC14
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,pineb101
@@ -10354,7 +10354,7 @@ info,hometeam,NY1
 info,date,1951/09/03
 info,site,NYC14
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,boggd901
@@ -10607,7 +10607,7 @@ info,hometeam,NY1
 info,date,1951/09/23
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,donaa901

--- a/event/regular/1951SLN.EVN
+++ b/event/regular/1951SLN.EVN
@@ -1804,7 +1804,7 @@ info,hometeam,SLN
 info,date,1951/05/26
 info,site,STL07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,pineb101
@@ -2808,7 +2808,7 @@ info,hometeam,SLN
 info,date,1951/06/17
 info,site,STL07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,balll901
@@ -3286,7 +3286,7 @@ info,hometeam,SLN
 info,date,1951/06/22
 info,site,STL07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,gorea901
@@ -6057,7 +6057,7 @@ info,hometeam,SLN
 info,date,1951/08/09
 info,site,STL07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,balll901

--- a/event/regular/1952.EBA
+++ b/event/regular/1952.EBA
@@ -5,7 +5,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1952/06/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,stevj901
@@ -105,7 +105,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1952/08/29
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,grieb901
@@ -210,7 +210,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1952/05/16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,duffj901
@@ -312,7 +312,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1952/06/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,berrc103
@@ -416,7 +416,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1952/07/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,honoj901
@@ -512,7 +512,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1952/07/27
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,grieb901
@@ -615,7 +615,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1952/07/27
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,passa901
@@ -712,7 +712,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1952/06/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,mcgob901
@@ -812,7 +812,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1952/06/22
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,soarh901
@@ -917,7 +917,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1952/06/22
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,robbs901
@@ -1022,7 +1022,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1952/07/29
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,summb901
@@ -1120,7 +1120,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1952/07/29
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,mckib901
@@ -1242,7 +1242,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1952/07/05
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,froeg901
@@ -1346,7 +1346,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1952/08/16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,froeg901
@@ -1451,7 +1451,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1952/08/17
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hurle901
@@ -1548,7 +1548,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1952/09/23
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,froeg901
@@ -1649,7 +1649,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1952/09/24
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,berrc103
@@ -1765,7 +1765,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1952/09/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,soarh901
@@ -1863,7 +1863,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1952/08/27
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,honoj901
@@ -1980,7 +1980,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1952/07/15
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,robbs901
@@ -2083,7 +2083,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1952/07/17
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,passa901
@@ -2187,7 +2187,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1952/07/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,robbs901
@@ -2292,7 +2292,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1952/09/12
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,grieb901
@@ -2409,7 +2409,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1952/06/23
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,passa901
@@ -2533,7 +2533,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1952/06/24
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,papaj901
@@ -2635,7 +2635,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1952/08/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,berrc103
@@ -2738,7 +2738,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1952/08/02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,papaj901
@@ -2856,7 +2856,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1952/08/03
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,duffj901
@@ -2954,7 +2954,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1952/08/03
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,romme101
@@ -3070,7 +3070,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1952/09/09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,passa901
@@ -3176,7 +3176,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1952/09/10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,robbs901
@@ -3278,7 +3278,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1952/05/18
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,papaj901
@@ -3387,7 +3387,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1952/05/13
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,romme101
@@ -3480,7 +3480,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1952/05/15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,soarh901
@@ -3570,7 +3570,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1952/06/14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stevj901
@@ -3674,7 +3674,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1952/06/15
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,summb901
@@ -3781,7 +3781,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1952/06/15
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,grieb901
@@ -3881,7 +3881,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1952/07/24
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,mcgob901
@@ -3978,7 +3978,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1952/09/14
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stevj901
@@ -4081,7 +4081,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1952/09/14
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,summb901
@@ -4174,7 +4174,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1952/06/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,grieb901
@@ -4281,7 +4281,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1952/06/27
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,stevj901
@@ -4387,7 +4387,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1952/06/28
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,honoj901
@@ -4485,7 +4485,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1952/08/05
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,froeg901
@@ -4587,7 +4587,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1952/08/06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,mcgob901
@@ -4689,7 +4689,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1952/08/31
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,berrc103
@@ -4800,7 +4800,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1952/07/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,soarh901
@@ -4917,7 +4917,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1952/08/09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,nappl901
@@ -5033,7 +5033,7 @@ info,hometeam,SLA
 info,site,STL07
 info,date,1952/07/22
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,soarh901

--- a/event/regular/1952.EBN
+++ b/event/regular/1952.EBN
@@ -5,7 +5,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1952/06/13
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,jordl901
@@ -105,7 +105,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1952/06/30
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,warnl101
@@ -201,7 +201,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1952/08/11
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,engeb902
@@ -302,7 +302,7 @@ info,hometeam,BSN
 info,site,BOS08
 info,date,1952/08/30
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,gorea901
@@ -418,7 +418,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1952/05/11
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,gugla901
@@ -527,7 +527,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1952/05/11
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,conlj102
@@ -631,7 +631,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1952/08/17
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,warnl101
@@ -731,7 +731,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1952/05/16
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,conlj102
@@ -834,7 +834,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1952/05/22
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,gugla901
@@ -936,7 +936,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1952/06/24
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,pineb101
@@ -1035,7 +1035,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1952/07/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,gugla901
@@ -1131,7 +1131,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1952/08/02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,boggd901
@@ -1229,7 +1229,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1952/09/09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,donaa901
@@ -1345,7 +1345,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1952/09/10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,balll901
@@ -1452,7 +1452,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1952/09/11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,barla901
@@ -1552,7 +1552,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1952/09/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,barla901
@@ -1662,7 +1662,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1952/04/22
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,donaa901
@@ -1768,7 +1768,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1952/05/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,secof101
@@ -1889,7 +1889,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1952/05/03
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dascf901
@@ -1997,7 +1997,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1952/05/06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,conlj102
@@ -2100,7 +2100,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1952/05/07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,gorea901
@@ -2197,7 +2197,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1952/05/23
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,secof101
@@ -2306,7 +2306,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1952/05/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,goetl901
@@ -2416,7 +2416,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1952/05/30
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dascf901
@@ -2529,7 +2529,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1952/05/30
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,secof101
@@ -2631,7 +2631,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1952/06/07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,balll901
@@ -2752,7 +2752,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1952/06/08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barla901
@@ -2859,7 +2859,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1952/06/28
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,pineb101
@@ -2966,7 +2966,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1952/06/29
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,engeb902
@@ -3057,7 +3057,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1952/07/15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,donaa901
@@ -3158,7 +3158,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1952/07/16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,balll901
@@ -3263,7 +3263,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1952/08/05
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,gugla901
@@ -3370,7 +3370,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1952/08/06
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,gorea901
@@ -3484,7 +3484,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1952/08/06
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,conlj102
@@ -3589,7 +3589,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1952/08/08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,stewb901
@@ -3685,7 +3685,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1952/08/10
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,gorea901
@@ -3795,7 +3795,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1952/08/10
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,conlj102
@@ -3904,7 +3904,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1952/08/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,gugla901
@@ -4010,7 +4010,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1952/08/27
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,engeb902
@@ -4122,7 +4122,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1952/08/28
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,boggd901
@@ -4233,7 +4233,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1952/08/30
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,donaa901
@@ -4330,7 +4330,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1952/08/31
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,balll901
@@ -4430,7 +4430,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1952/09/01
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,boggd901
@@ -4527,7 +4527,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1952/09/01
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,jackb901
@@ -4640,7 +4640,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1952/08/09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,gugla901
@@ -4741,7 +4741,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1952/04/16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barla901
@@ -4863,7 +4863,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1952/04/27
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,boggd901
@@ -4965,7 +4965,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1952/04/28
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,robbs901
@@ -5075,7 +5075,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1952/05/02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,donaa901
@@ -5167,7 +5167,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1952/05/03
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,balll901
@@ -5267,7 +5267,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1952/06/01
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stewb901
@@ -5399,7 +5399,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1952/06/01
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,gugla901
@@ -5504,7 +5504,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1952/06/02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,gorea901
@@ -5621,7 +5621,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1952/06/06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,goetl901
@@ -5726,7 +5726,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1952/06/08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,secof101
@@ -5828,7 +5828,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1952/07/04
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barla901
@@ -5946,7 +5946,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1952/07/04
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,gormt101
@@ -6042,7 +6042,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1952/07/06
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,balll901
@@ -6151,7 +6151,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1952/07/11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,gorea901
@@ -6254,7 +6254,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1952/07/15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,boggd901
@@ -6362,7 +6362,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1952/07/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,dascf901
@@ -6460,7 +6460,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1952/08/14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,dascf901
@@ -6562,7 +6562,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1952/08/15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,warnl101
@@ -6669,7 +6669,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1952/09/04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,engeb902
@@ -6775,7 +6775,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1952/09/05
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,boggd901
@@ -6874,7 +6874,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1952/09/07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,pineb101
@@ -6994,7 +6994,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1952/09/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,stewb901
@@ -7092,7 +7092,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1952/09/27
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,conlj102
@@ -7202,7 +7202,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1952/04/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,gormt101
@@ -7309,7 +7309,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1952/05/04
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,goetl901
@@ -7421,7 +7421,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1952/05/08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,boggd901
@@ -7518,7 +7518,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1952/07/03
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,balll901
@@ -7615,7 +7615,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1952/04/30
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,pineb101
@@ -7753,7 +7753,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1952/09/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,secof101
@@ -7868,7 +7868,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1952/08/21
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,conlj102
@@ -7982,7 +7982,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1952/07/16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,secof101

--- a/event/regular/1953.EBA
+++ b/event/regular/1953.EBA
@@ -5,7 +5,7 @@ info,hometeam,NYA
 info,date,1953/08/01
 info,site,NYC16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,passa901
@@ -100,7 +100,7 @@ info,hometeam,PHA
 info,date,1953/07/06
 info,site,PHI11
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,mckib901
@@ -204,7 +204,7 @@ info,hometeam,SLA
 info,date,1953/04/28
 info,site,STL07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,froeg901
@@ -321,7 +321,7 @@ info,hometeam,SLA
 info,date,1953/06/05
 info,site,STL07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,mckib901
@@ -418,7 +418,7 @@ info,hometeam,SLA
 info,date,1953/06/07
 info,site,STL07
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,papaj901
@@ -527,7 +527,7 @@ info,hometeam,SLA
 info,date,1953/06/12
 info,site,STL07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,hurle901
@@ -626,7 +626,7 @@ info,hometeam,SLA
 info,date,1953/06/14
 info,site,STL07
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,berrc103
@@ -723,7 +723,7 @@ info,hometeam,SLA
 info,date,1953/06/14
 info,site,STL07
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hurle901
@@ -821,7 +821,7 @@ info,hometeam,SLA
 info,date,1953/07/16
 info,site,STL07
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,nappl901
@@ -938,7 +938,7 @@ info,hometeam,SLA
 info,date,1953/07/17
 info,site,STL07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,grieb901
@@ -1055,7 +1055,7 @@ info,hometeam,SLA
 info,date,1953/07/22
 info,site,STL07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,duffj901
@@ -1149,7 +1149,7 @@ info,hometeam,SLA
 info,date,1953/08/27
 info,site,STL07
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,mcgob901
@@ -1258,7 +1258,7 @@ info,hometeam,SLA
 info,date,1953/08/28
 info,site,STL07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,papaj901
@@ -1361,7 +1361,7 @@ info,hometeam,SLA
 info,date,1953/09/03
 info,site,STL07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,froeg901

--- a/event/regular/1953.EBN
+++ b/event/regular/1953.EBN
@@ -5,7 +5,7 @@ info,hometeam,CHN
 info,date,1953/04/26
 info,site,CHI11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,warnl101
@@ -134,7 +134,7 @@ info,hometeam,CHN
 info,date,1953/05/17
 info,site,CHI11
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,balll901
@@ -253,7 +253,7 @@ info,hometeam,CHN
 info,date,1953/06/16
 info,site,CHI11
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,balll901
@@ -360,7 +360,7 @@ info,hometeam,CHN
 info,date,1953/07/04
 info,site,CHI11
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,gormt101
@@ -484,7 +484,7 @@ info,hometeam,CHN
 info,date,1953/08/01
 info,site,CHI11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stewb901
@@ -607,7 +607,7 @@ info,hometeam,CHN
 info,date,1953/08/02
 info,site,CHI11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,pineb101
@@ -737,7 +737,7 @@ info,hometeam,MLN
 info,date,1953/05/10
 info,site,MIL05
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dixoh901
@@ -837,7 +837,7 @@ info,hometeam,MLN
 info,date,1953/06/16
 info,site,MIL05
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,warnl101
@@ -970,7 +970,7 @@ info,hometeam,MLN
 info,date,1953/06/16
 info,site,MIL05
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,gormt101
@@ -1066,7 +1066,7 @@ info,hometeam,MLN
 info,date,1953/06/21
 info,site,MIL05
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,jackb901
@@ -1182,7 +1182,7 @@ info,hometeam,MLN
 info,date,1953/06/23
 info,site,MIL05
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,secof101
@@ -1279,7 +1279,7 @@ info,hometeam,MLN
 info,date,1953/06/24
 info,site,MIL05
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dixoh901
@@ -1387,7 +1387,7 @@ info,hometeam,MLN
 info,date,1953/07/05
 info,site,MIL05
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,jackb901
@@ -1488,7 +1488,7 @@ info,hometeam,MLN
 info,date,1953/08/07
 info,site,MIL05
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,balll901
@@ -1598,7 +1598,7 @@ info,hometeam,MLN
 info,date,1953/08/09
 info,site,MIL05
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,jackb901
@@ -1710,7 +1710,7 @@ info,hometeam,MLN
 info,date,1953/08/10
 info,site,MIL05
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,boggd901
@@ -1817,7 +1817,7 @@ info,hometeam,MLN
 info,date,1953/08/11
 info,site,MIL05
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,engeb902
@@ -1919,7 +1919,7 @@ info,hometeam,MLN
 info,date,1953/08/22
 info,site,MIL05
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dixoh901
@@ -2035,7 +2035,7 @@ info,hometeam,MLN
 info,date,1953/09/06
 info,site,MIL05
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,conlj102
@@ -2144,7 +2144,7 @@ info,hometeam,MLN
 info,date,1953/09/06
 info,site,MIL05
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,gormt101
@@ -2260,7 +2260,7 @@ info,hometeam,MLN
 info,date,1953/09/15
 info,site,MIL05
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,barla901
@@ -2373,7 +2373,7 @@ info,hometeam,NY1
 info,date,1953/06/12
 info,site,NYC14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,warnl101
@@ -2499,7 +2499,7 @@ info,hometeam,PIT
 info,date,1953/04/16
 info,site,PIT06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,secof101
@@ -2629,7 +2629,7 @@ info,hometeam,PIT
 info,date,1953/04/28
 info,site,PIT06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,donaa901
@@ -2743,7 +2743,7 @@ info,hometeam,PIT
 info,date,1953/04/29
 info,site,PIT06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,gormt101
@@ -2853,7 +2853,7 @@ info,hometeam,PIT
 info,date,1953/05/03
 info,site,PIT06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,secof101
@@ -2966,7 +2966,7 @@ info,hometeam,PIT
 info,date,1953/05/04
 info,site,PIT06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,dixoh901
@@ -3073,7 +3073,7 @@ info,hometeam,PIT
 info,date,1953/05/21
 info,site,PIT06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,gorea901
@@ -3174,7 +3174,7 @@ info,hometeam,PIT
 info,date,1953/05/28
 info,site,PIT06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,conlj102
@@ -3288,7 +3288,7 @@ info,hometeam,PIT
 info,date,1953/06/02
 info,site,PIT06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,warnl101
@@ -3417,7 +3417,7 @@ info,hometeam,PIT
 info,date,1953/06/03
 info,site,PIT06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,donaa901
@@ -3509,7 +3509,7 @@ info,hometeam,PIT
 info,date,1953/06/10
 info,site,PIT06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,barla901
@@ -3624,7 +3624,7 @@ info,hometeam,PIT
 info,date,1953/06/12
 info,site,PIT06
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,pineb101
@@ -3720,7 +3720,7 @@ info,hometeam,PIT
 info,date,1953/06/14
 info,site,PIT06
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stewb901
@@ -3817,7 +3817,7 @@ info,hometeam,PIT
 info,date,1953/06/14
 info,site,PIT06
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,pineb101
@@ -3927,7 +3927,7 @@ info,hometeam,PIT
 info,date,1953/06/15
 info,site,PIT06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,boggd901
@@ -4032,7 +4032,7 @@ info,hometeam,PIT
 info,date,1953/07/16
 info,site,PIT06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,dascf901
@@ -4136,7 +4136,7 @@ info,hometeam,PIT
 info,date,1953/07/17
 info,site,PIT06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,secof101
@@ -4236,7 +4236,7 @@ info,hometeam,PIT
 info,date,1953/07/19
 info,site,PIT06
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,boggd901
@@ -4335,7 +4335,7 @@ info,hometeam,PIT
 info,date,1953/07/24
 info,site,PIT06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,donaa901
@@ -4433,7 +4433,7 @@ info,hometeam,PIT
 info,date,1953/07/26
 info,site,PIT06
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,warnl101
@@ -4541,7 +4541,7 @@ info,hometeam,PIT
 info,date,1953/07/26
 info,site,PIT06
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,gormt101
@@ -4658,7 +4658,7 @@ info,hometeam,PIT
 info,date,1953/08/29
 info,site,PIT06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dascf901
@@ -4777,7 +4777,7 @@ info,hometeam,PIT
 info,date,1953/08/30
 info,site,PIT06
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,pineb101
@@ -4908,7 +4908,7 @@ info,hometeam,PIT
 info,date,1953/08/30
 info,site,PIT06
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,boggd901
@@ -5026,7 +5026,7 @@ info,hometeam,PIT
 info,date,1953/09/02
 info,site,PIT06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,engeb902
@@ -5128,7 +5128,7 @@ info,hometeam,PIT
 info,date,1953/09/25
 info,site,PIT06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,jackb901
@@ -5230,7 +5230,7 @@ info,hometeam,PIT
 info,date,1953/09/26
 info,site,PIT06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barla901
@@ -5340,7 +5340,7 @@ info,hometeam,PIT
 info,date,1953/09/27
 info,site,PIT06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,balll901
@@ -5449,7 +5449,7 @@ info,hometeam,SLN
 info,date,1953/04/16
 info,site,STL07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,gorea901
@@ -5555,7 +5555,7 @@ info,hometeam,SLN
 info,date,1953/04/19
 info,site,STL07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,jackb901
@@ -5671,7 +5671,7 @@ info,hometeam,SLN
 info,date,1953/04/20
 info,site,STL07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,balll901
@@ -5792,7 +5792,7 @@ info,hometeam,SLN
 info,date,1953/05/12
 info,site,STL07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,balll901
@@ -5905,7 +5905,7 @@ info,hometeam,SLN
 info,date,1953/05/20
 info,site,STL07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,boggd901
@@ -6024,7 +6024,7 @@ info,hometeam,SLN
 info,date,1953/05/30
 info,site,STL07
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,pineb101
@@ -6149,7 +6149,7 @@ info,hometeam,SLN
 info,date,1953/06/19
 info,site,STL07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,engeb902
@@ -6264,7 +6264,7 @@ info,hometeam,SLN
 info,date,1953/06/20
 info,site,STL07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,stewb901
@@ -6362,7 +6362,7 @@ info,hometeam,SLN
 info,date,1953/06/21
 info,site,STL07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,pineb101
@@ -6468,7 +6468,7 @@ info,hometeam,SLN
 info,date,1953/06/22
 info,site,STL07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,boggd901
@@ -6565,7 +6565,7 @@ info,hometeam,SLN
 info,date,1953/06/28
 info,site,STL07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barla901
@@ -6670,7 +6670,7 @@ info,hometeam,SLN
 info,date,1953/07/11
 info,site,STL07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,warnl101
@@ -6778,7 +6778,7 @@ info,hometeam,SLN
 info,date,1953/07/12
 info,site,STL07
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,gormt101
@@ -6897,7 +6897,7 @@ info,hometeam,SLN
 info,date,1953/07/12
 info,site,STL07
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,donaa901
@@ -7015,7 +7015,7 @@ info,hometeam,SLN
 info,date,1953/07/29
 info,site,STL07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,conlj102
@@ -7123,7 +7123,7 @@ info,hometeam,SLN
 info,date,1953/07/30
 info,site,STL07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,warnl101
@@ -7237,7 +7237,7 @@ info,hometeam,SLN
 info,date,1953/09/11
 info,site,STL07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,donaa901
@@ -7345,7 +7345,7 @@ info,hometeam,SLN
 info,date,1953/09/12
 info,site,STL07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,warnl101
@@ -7478,7 +7478,7 @@ info,hometeam,SLN
 info,date,1953/09/19
 info,site,STL07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,dixoh901
@@ -7604,7 +7604,7 @@ info,hometeam,SLN
 info,date,1953/09/20
 info,site,STL07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,secof101
@@ -7726,7 +7726,7 @@ info,hometeam,SLN
 info,date,1953/09/22
 info,site,STL07
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,stewb901
@@ -7828,7 +7828,7 @@ info,hometeam,SLN
 info,date,1953/09/22
 info,site,STL07
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,boggd901
@@ -7954,7 +7954,7 @@ info,hometeam,CHN
 info,date,1953/05/26
 info,site,CHI11
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,secof101
@@ -8071,7 +8071,7 @@ info,hometeam,CHN
 info,date,1953/07/03
 info,site,CHI11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,conlj102
@@ -8199,7 +8199,7 @@ info,hometeam,CHN
 info,date,1953/09/17
 info,site,CHI11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stewb901
@@ -8314,7 +8314,7 @@ info,hometeam,CHN
 info,date,1953/09/25
 info,site,CHI11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,engeb902
@@ -8428,7 +8428,7 @@ info,hometeam,CHN
 info,date,1953/09/26
 info,site,CHI11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stewb901
@@ -8538,7 +8538,7 @@ info,hometeam,PIT
 info,date,1953/06/08
 info,site,PIT06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,balll901
@@ -8664,7 +8664,7 @@ info,hometeam,SLN
 info,date,1953/05/31
 info,site,STL07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,boggd901
@@ -8770,7 +8770,7 @@ info,hometeam,CHN
 info,date,1953/05/17
 info,site,CHI11
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,gorea901
@@ -8878,7 +8878,7 @@ info,hometeam,PIT
 info,date,1953/05/27
 info,site,PIT06
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,donaa901
@@ -8998,7 +8998,7 @@ info,hometeam,MLN
 info,date,1953/05/10
 info,site,MIL05
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,secof101
@@ -9104,7 +9104,7 @@ info,hometeam,SLN
 info,date,1953/05/19
 info,site,STL07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,pineb101
@@ -9209,7 +9209,7 @@ info,hometeam,PIT
 info,date,1953/08/28
 info,site,PIT06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,secof101
@@ -9348,7 +9348,7 @@ info,hometeam,CHN
 info,date,1953/05/16
 info,site,CHI11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,jackb901
@@ -9473,7 +9473,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1953/06/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barla901
@@ -9588,7 +9588,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1953/06/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,jackb901
@@ -9706,7 +9706,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1953/09/21
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,scorer,"daily + TSN box"

--- a/event/regular/1953.EDA
+++ b/event/regular/1953.EDA
@@ -5,7 +5,7 @@ info,hometeam,PHA
 info,date,1953/07/06
 info,site,PHI11
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,mckib901
@@ -337,7 +337,7 @@ info,hometeam,SLA
 info,date,1953/06/12
 info,site,STL07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,hurle901
@@ -474,7 +474,7 @@ info,hometeam,SLA
 info,date,1953/06/14
 info,site,STL07
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,berrc103
@@ -613,7 +613,7 @@ info,hometeam,SLA
 info,date,1953/06/14
 info,site,STL07
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hurle901
@@ -746,7 +746,7 @@ info,hometeam,SLA
 info,date,1953/07/22
 info,site,STL07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,duffj901
@@ -891,7 +891,7 @@ info,hometeam,SLA
 info,date,1953/08/27
 info,site,STL07
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,mcgob901
@@ -1030,7 +1030,7 @@ info,hometeam,SLA
 info,date,1953/08/28
 info,site,STL07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,papaj901

--- a/event/regular/1953.EDN
+++ b/event/regular/1953.EDN
@@ -5,7 +5,7 @@ info,hometeam,MLN
 info,date,1953/06/16
 info,site,MIL05
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,warnl101
@@ -188,7 +188,7 @@ info,hometeam,MLN
 info,date,1953/06/16
 info,site,MIL05
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,gormt101

--- a/event/regular/1953CHA.EVA
+++ b/event/regular/1953CHA.EVA
@@ -5279,7 +5279,7 @@ info,hometeam,CHA
 info,date,1953/06/30
 info,site,CHI10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,summb901
@@ -5423,7 +5423,7 @@ info,hometeam,CHA
 info,date,1953/07/01
 info,site,CHI10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,berrc103

--- a/event/regular/1953NYA.EVA
+++ b/event/regular/1953NYA.EVA
@@ -4815,7 +4815,7 @@ info,hometeam,NYA
 info,date,1953/06/26
 info,site,NYC16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,hurle901
@@ -4955,7 +4955,7 @@ info,hometeam,NYA
 info,date,1953/06/27
 info,site,NYC16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,romme101
@@ -5092,7 +5092,7 @@ info,hometeam,NYA
 info,date,1953/06/28
 info,site,NYC16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,romme101

--- a/event/regular/1953PHA.EVA
+++ b/event/regular/1953PHA.EVA
@@ -4907,7 +4907,7 @@ info,hometeam,PHA
 info,date,1953/06/30
 info,site,PHI11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,hurle901
@@ -5031,7 +5031,7 @@ info,hometeam,PHA
 info,date,1953/07/01
 info,site,PHI11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,soarh901

--- a/event/regular/1953SLA.EVA
+++ b/event/regular/1953SLA.EVA
@@ -1641,7 +1641,7 @@ info,hometeam,SLA
 info,date,1953/05/06
 info,site,STL07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,duffj901

--- a/event/regular/1953SLN.EVN
+++ b/event/regular/1953SLN.EVN
@@ -3664,7 +3664,7 @@ info,hometeam,SLN
 info,date,1953/06/27
 info,site,STL07
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,gorea901
@@ -3937,7 +3937,7 @@ info,hometeam,SLN
 info,date,1953/06/28
 info,site,STL07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barla901

--- a/event/regular/1954.EBA
+++ b/event/regular/1954.EBA
@@ -5,7 +5,7 @@ info,hometeam,NYA
 info,site,
 info,date,1954/08/12
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,chyln901
@@ -105,7 +105,7 @@ info,hometeam,NYA
 info,site,
 info,date,1954/09/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,honoj901
@@ -230,7 +230,7 @@ info,hometeam,PHA
 info,site,PHI11
 info,date,1954/08/31
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,summb901

--- a/event/regular/1954.EBN
+++ b/event/regular/1954.EBN
@@ -5,7 +5,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1954/04/30
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,boggd901
@@ -112,7 +112,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1954/05/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,engeb902
@@ -219,7 +219,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1954/05/02
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,jackb901
@@ -328,7 +328,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1954/05/22
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dascf901
@@ -453,7 +453,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1954/06/09
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dixoh901
@@ -566,7 +566,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1954/07/15
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,warnl101
@@ -678,7 +678,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1954/07/16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,secof101
@@ -778,7 +778,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1954/07/17
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,goetl901
@@ -887,7 +887,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1954/07/17
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dascf901
@@ -999,7 +999,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1954/08/28
 info,number,D
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,gormt101
@@ -1107,7 +1107,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1954/08/31
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barla901
@@ -1206,7 +1206,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1954/08/31
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dixoh901
@@ -1312,7 +1312,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1954/09/22
 info,number,D
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,gorea901
@@ -1412,7 +1412,7 @@ info,hometeam,MLN
 info,site,MIL05
 info,date,1954/05/04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,warnl101
@@ -1516,7 +1516,7 @@ info,hometeam,MLN
 info,site,MIL05
 info,date,1954/06/13
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,boggd901
@@ -1629,7 +1629,7 @@ info,hometeam,MLN
 info,site,MIL05
 info,date,1954/06/30
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,gormt101
@@ -1748,7 +1748,7 @@ info,hometeam,MLN
 info,site,MIL05
 info,date,1954/07/18
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,conlj102
@@ -1852,7 +1852,7 @@ info,hometeam,MLN
 info,site,MIL05
 info,date,1954/07/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,gormt101
@@ -1950,7 +1950,7 @@ info,hometeam,MLN
 info,site,MIL05
 info,date,1954/07/21
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,warnl101
@@ -2059,7 +2059,7 @@ info,hometeam,MLN
 info,site,MIL05
 info,date,1954/08/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dascf901
@@ -2158,7 +2158,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1954/05/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,donaa901
@@ -2267,7 +2267,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1954/05/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,balll901
@@ -2365,7 +2365,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1954/07/06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,goetl901
@@ -2464,7 +2464,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1954/09/11
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,jackb901
@@ -2561,7 +2561,7 @@ info,hometeam,PHI
 info,site,PHI11
 info,date,1954/09/15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,goetl901
@@ -2656,7 +2656,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1954/04/29
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,dascf901
@@ -2781,7 +2781,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1954/05/03
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,barla901
@@ -2884,7 +2884,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1954/05/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,dascf901
@@ -2997,7 +2997,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1954/06/12
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,barla901
@@ -3106,7 +3106,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1954/06/13
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,balll901
@@ -3206,7 +3206,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1954/06/13
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,jackb901
@@ -3333,7 +3333,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1954/07/10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,dixoh901
@@ -3441,7 +3441,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1954/07/11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,balll901
@@ -3543,7 +3543,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1954/07/18
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stewb901
@@ -3688,7 +3688,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1954/07/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,boggd901
@@ -3792,7 +3792,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1954/07/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,engeb902
@@ -3894,7 +3894,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1954/07/22
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,barla901
@@ -4012,7 +4012,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1954/08/10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,engeb902
@@ -4119,7 +4119,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1954/08/26
 info,number,d
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,conlj102
@@ -4234,7 +4234,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1954/09/03
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,goetl901
@@ -4359,7 +4359,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1954/09/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,donaa901
@@ -4478,7 +4478,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1954/09/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,conlj102
@@ -4583,7 +4583,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1954/07/03
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,gormt101
@@ -4682,7 +4682,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1954/05/09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,warnl101
@@ -4773,7 +4773,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1954/05/13
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,goetl901
@@ -4879,7 +4879,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1954/05/14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,dascf901
@@ -4978,7 +4978,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1954/05/16
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,balll901
@@ -5090,7 +5090,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1954/05/16
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barla901
@@ -5197,7 +5197,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1954/05/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,warnl101
@@ -5315,7 +5315,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1954/05/29
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,warnl101
@@ -5427,7 +5427,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1954/06/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,barla901
@@ -5522,7 +5522,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1954/06/20
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,balll901
@@ -5633,7 +5633,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1954/06/23
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,pineb101
@@ -5742,7 +5742,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1954/07/03
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,secof101
@@ -5856,7 +5856,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1954/07/04
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,goetl901
@@ -5967,7 +5967,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1954/07/04
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dascf901
@@ -6080,7 +6080,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1954/07/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,gormt101
@@ -6183,7 +6183,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1954/07/28
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,donaa901
@@ -6288,7 +6288,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1954/07/30
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,warnl101
@@ -6403,7 +6403,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1954/07/30
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,secof101
@@ -6520,7 +6520,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1954/07/31
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,goetl901
@@ -6632,7 +6632,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1954/08/01
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dascf901
@@ -6732,7 +6732,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1954/08/06
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,balll901
@@ -6842,7 +6842,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1954/08/06
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,jackb901
@@ -6951,7 +6951,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1954/09/03
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,conlj102
@@ -7053,7 +7053,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1954/09/10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,stewb901
@@ -7159,7 +7159,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1954/09/11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,boggd901
@@ -7254,7 +7254,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1954/09/14
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,gorea901
@@ -7355,7 +7355,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1954/09/14
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,gormt101
@@ -7453,7 +7453,7 @@ info,hometeam,MLN
 info,site,MIL05
 info,date,1954/05/07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,boggd901
@@ -7556,7 +7556,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1954/07/08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,jackb901

--- a/event/regular/1954.EDN
+++ b/event/regular/1954.EDN
@@ -285,7 +285,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1954/06/09
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dixoh901
@@ -2250,7 +2250,7 @@ info,hometeam,MLN
 info,site,MIL05
 info,date,1954/07/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,gormt101
@@ -2374,7 +2374,7 @@ info,hometeam,MLN
 info,site,MIL05
 info,date,1954/07/21
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,warnl101
@@ -4704,7 +4704,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1954/07/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,gormt101
@@ -7368,7 +7368,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1954/07/18
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stewb901
@@ -7589,7 +7589,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1954/07/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,boggd901
@@ -7723,7 +7723,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1954/07/22
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,barla901

--- a/event/regular/1954SLN.EVN
+++ b/event/regular/1954SLN.EVN
@@ -6441,7 +6441,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1954/07/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,engeb902

--- a/event/regular/1955.EBA
+++ b/event/regular/1955.EBA
@@ -5,7 +5,7 @@ info,hometeam,KC1
 info,site,KAN05
 info,date,1955/08/23
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,stevj901

--- a/event/regular/1955.EBN
+++ b/event/regular/1955.EBN
@@ -5,7 +5,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1955/05/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,engeb902
@@ -105,7 +105,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1955/07/27
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,goetl901
@@ -255,7 +255,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1955/09/03
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,gormt101
@@ -372,7 +372,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1955/09/07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,gormt101
@@ -461,7 +461,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1955/09/11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,goetl901
@@ -578,7 +578,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1955/05/14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,boggd901
@@ -686,7 +686,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1955/07/31
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,jackb901
@@ -796,7 +796,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1955/08/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,conlj102
@@ -900,7 +900,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1955/08/04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,conlj102
@@ -1022,7 +1022,7 @@ info,hometeam,MLN
 info,site,MIL05
 info,date,1955/05/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,gormt101
@@ -1133,7 +1133,7 @@ info,hometeam,MLN
 info,site,MIL05
 info,date,1955/06/14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,secof101
@@ -1227,7 +1227,7 @@ info,hometeam,MLN
 info,site,MIL05
 info,date,1955/06/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,donaa901
@@ -1323,7 +1323,7 @@ info,hometeam,MLN
 info,site,MIL05
 info,date,1955/06/21
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,dixoh901
@@ -1431,7 +1431,7 @@ info,hometeam,MLN
 info,site,MIL05
 info,date,1955/06/29
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,gorea901
@@ -1534,7 +1534,7 @@ info,hometeam,MLN
 info,site,MIL05
 info,date,1955/07/31
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,engeb902
@@ -1636,7 +1636,7 @@ info,hometeam,MLN
 info,site,MIL05
 info,date,1955/08/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,lands901
@@ -1734,7 +1734,7 @@ info,hometeam,MLN
 info,site,MIL05
 info,date,1955/08/21
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,balll901
@@ -1841,7 +1841,7 @@ info,hometeam,MLN
 info,site,MIL05
 info,date,1955/09/09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,conlj102
@@ -1938,7 +1938,7 @@ info,hometeam,MLN
 info,site,MIL05
 info,date,1955/09/16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,secof101
@@ -2044,7 +2044,7 @@ info,hometeam,MLN
 info,site,MIL05
 info,date,1955/09/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,goetl901
@@ -2156,7 +2156,7 @@ info,hometeam,MLN
 info,site,MIL05
 info,date,1955/05/10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,balll901
@@ -2269,7 +2269,7 @@ info,hometeam,MLN
 info,site,MIL05
 info,date,1955/05/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,gorea901
@@ -2380,7 +2380,7 @@ info,hometeam,MLN
 info,site,MIL05
 info,date,1955/05/22
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,pineb101
@@ -2483,7 +2483,7 @@ info,hometeam,MLN
 info,site,MIL05
 info,date,1955/08/05
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,lands901
@@ -2597,7 +2597,7 @@ info,hometeam,MLN
 info,site,MIL05
 info,date,1955/08/09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,pineb101
@@ -2694,7 +2694,7 @@ info,hometeam,MLN
 info,site,MIL05
 info,date,1955/08/10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,gormt101
@@ -2796,7 +2796,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1955/06/04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,pineb101
@@ -2937,7 +2937,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1955/07/07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,boggd901
@@ -3064,7 +3064,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1955/07/15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dixoh901
@@ -3166,7 +3166,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1955/07/17
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barla901
@@ -3269,7 +3269,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1955/07/19
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,warnl101
@@ -3370,7 +3370,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1955/08/28
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,engeb902
@@ -3472,7 +3472,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1955/09/20
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,lands901
@@ -3591,7 +3591,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1955/09/21
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dixoh901
@@ -3694,7 +3694,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1955/09/23
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,conlj102
@@ -3798,7 +3798,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1955/05/05
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,lands901
@@ -3902,7 +3902,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1955/05/07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,goetl901
@@ -4014,7 +4014,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1955/05/29
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,conlj102
@@ -4146,7 +4146,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1955/06/07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,donaa901
@@ -4265,7 +4265,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1955/06/08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,dixoh901
@@ -4361,7 +4361,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1955/06/12
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,gormt101
@@ -4465,7 +4465,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1955/07/04
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,boggd901
@@ -4583,7 +4583,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1955/07/04
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,engeb902
@@ -4721,7 +4721,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1955/07/17
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,gormt101
@@ -4861,7 +4861,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1955/07/17
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,boggd901
@@ -4976,7 +4976,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1955/07/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,gorea901
@@ -5102,7 +5102,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1955/07/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,donaa901
@@ -5213,7 +5213,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1955/07/22
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,balll901
@@ -5314,7 +5314,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1955/07/23
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barla901
@@ -5413,7 +5413,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1955/07/24
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,jackb901
@@ -5517,7 +5517,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1955/07/24
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,lands901
@@ -5612,7 +5612,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1955/08/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dixoh901
@@ -5755,7 +5755,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1955/08/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,lands901
@@ -5857,7 +5857,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1955/08/27
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,balll901
@@ -5964,7 +5964,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1955/08/28
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barla901
@@ -6077,7 +6077,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1955/08/28
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,jackb901
@@ -6178,7 +6178,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1955/08/30
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,secof101
@@ -6280,7 +6280,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1955/08/31
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,goetl901
@@ -6378,7 +6378,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1955/04/27
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,secof101
@@ -6479,7 +6479,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1955/05/01
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,engeb902
@@ -6593,7 +6593,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1955/05/01
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,pineb101
@@ -6698,7 +6698,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1955/05/03
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,gorea901
@@ -6800,7 +6800,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1955/05/21
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,goetl901
@@ -6918,7 +6918,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1955/05/22
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dascf901
@@ -7015,7 +7015,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1955/05/22
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,warnl101
@@ -7135,7 +7135,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1955/08/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,warnl101
@@ -7242,7 +7242,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1955/08/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,conlj102
@@ -7350,7 +7350,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1955/05/30
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,jackb901
@@ -7467,7 +7467,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1955/06/14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,balll901
@@ -7581,7 +7581,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1955/06/15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,barla901
@@ -7684,7 +7684,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1955/06/16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,jackb901
@@ -7787,7 +7787,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1955/07/09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,warnl101
@@ -7891,7 +7891,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1955/08/03
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,barla901
@@ -8004,7 +8004,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1955/09/08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,dixoh901
@@ -8110,7 +8110,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1955/09/10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,engeb902
@@ -8202,7 +8202,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1955/09/11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,pineb101
@@ -8303,7 +8303,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1955/09/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,warnl101
@@ -8416,7 +8416,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1955/04/16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,donaa901
@@ -8573,7 +8573,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1955/04/17
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dixoh901
@@ -8701,7 +8701,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1955/04/17
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,conlj102
@@ -8810,7 +8810,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1955/05/07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,boggd901
@@ -8945,7 +8945,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1955/05/08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,gormt101
@@ -9055,7 +9055,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1955/05/14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,donaa901
@@ -9149,7 +9149,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1955/07/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,boggd901
@@ -9241,7 +9241,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1955/07/27
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,engeb902
@@ -9336,7 +9336,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1955/08/15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,jackb901
@@ -9448,7 +9448,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1955/08/16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,lands901
@@ -9551,7 +9551,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1955/08/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,balll901
@@ -9660,7 +9660,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1955/08/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,barla901
@@ -9762,7 +9762,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1955/07/08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,dascf901

--- a/event/regular/1955.EDA
+++ b/event/regular/1955.EDA
@@ -5,7 +5,7 @@ info,hometeam,KC1
 info,site,KAN05
 info,date,1955/08/23
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,stevj901

--- a/event/regular/1955.EDN
+++ b/event/regular/1955.EDN
@@ -448,7 +448,7 @@ info,hometeam,MLN
 info,site,MIL05
 info,date,1955/06/14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,unknown
 info,usedh,false
 info,umphome,secof101
@@ -570,7 +570,7 @@ info,hometeam,MLN
 info,site,MIL05
 info,date,1955/06/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,unknown
 info,usedh,false
 info,umphome,donaa901
@@ -689,7 +689,7 @@ info,hometeam,MLN
 info,site,MIL05
 info,date,1955/06/21
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,unknown
 info,usedh,false
 info,umphome,dixoh901
@@ -981,7 +981,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1955/05/07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,unknown
 info,usedh,false
 info,umphome,goetl901
@@ -1139,7 +1139,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1955/06/04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,unknown
 info,usedh,false
 info,umphome,pineb101
@@ -1481,7 +1481,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1955/09/20
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,lands901
@@ -1655,7 +1655,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1955/09/21
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dixoh901
@@ -1797,7 +1797,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1955/09/23
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,conlj102
@@ -2931,7 +2931,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1955/07/22
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,unknown
 info,usedh,false
 info,umphome,balll901
@@ -3065,7 +3065,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1955/07/23
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,unknown
 info,usedh,false
 info,umphome,barla901
@@ -3196,7 +3196,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1955/07/24
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,unknown
 info,usedh,false
 info,umphome,jackb901
@@ -3341,7 +3341,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1955/07/24
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,unknown
 info,usedh,false
 info,umphome,lands901
@@ -4189,7 +4189,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1955/05/30
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,unknown
 info,usedh,false
 info,umphome,jackb901

--- a/event/regular/1955BAL.EVA
+++ b/event/regular/1955BAL.EVA
@@ -11919,7 +11919,7 @@ info,hometeam,BAL
 info,date,1955/09/17
 info,site,BAL11
 info,number,0
-info,starttime,0:00AM
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,papaj901

--- a/event/regular/1955MLN.EVN
+++ b/event/regular/1955MLN.EVN
@@ -1628,7 +1628,7 @@ info,hometeam,MLN
 info,site,MIL05
 info,date,1955/05/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,unknown
 info,usedh,false
 info,umphome,gorea901

--- a/event/regular/1955SLN.EVN
+++ b/event/regular/1955SLN.EVN
@@ -1499,7 +1499,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1955/05/14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,unknown
 info,usedh,false
 info,umphome,donaa901

--- a/event/regular/1956.EBA
+++ b/event/regular/1956.EBA
@@ -5,7 +5,7 @@ info,hometeam,KC1
 info,site,KAN05
 info,date,1956/07/24
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,nappl901
@@ -111,7 +111,7 @@ info,hometeam,KC1
 info,site,KAN05
 info,date,1956/09/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,soarh901
@@ -242,7 +242,7 @@ info,hometeam,KC1
 info,site,KAN05
 info,date,1956/09/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,papaj901

--- a/event/regular/1956.EBN
+++ b/event/regular/1956.EBN
@@ -5,7 +5,7 @@ info,hometeam,MLN
 info,site,MIL05
 info,date,1956/06/03
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,conlj102
@@ -113,7 +113,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1956/06/05
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,gorea901
@@ -225,7 +225,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1956/06/23
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,gormt101
@@ -352,7 +352,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1956/09/12
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,craws901
@@ -455,7 +455,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1956/05/02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,gormt101
@@ -634,7 +634,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1956/06/07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,craws901
@@ -737,7 +737,7 @@ info,hometeam,MLN
 info,site,MIL05
 info,date,1956/07/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,jackb901
@@ -893,7 +893,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1956/07/12
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,boggd901
@@ -995,7 +995,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1956/04/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dascf901
@@ -1130,7 +1130,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1956/04/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,secof101
@@ -1247,7 +1247,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1956/05/16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,donaa901
@@ -1358,7 +1358,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1956/05/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,boggd901
@@ -1469,7 +1469,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1956/05/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,gormt101
@@ -1586,7 +1586,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1956/05/20
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,donaa901
@@ -1693,7 +1693,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1956/05/20
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,engeb902
@@ -1793,7 +1793,7 @@ info,hometeam,MLN
 info,site,MIL05
 info,date,1956/06/03
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,delmv901
@@ -1908,7 +1908,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1956/06/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,engeb902
@@ -2005,7 +2005,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1956/06/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,delmv901
@@ -2117,7 +2117,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1956/06/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,conlj102
@@ -2220,7 +2220,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1956/06/24
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,pineb101
@@ -2328,7 +2328,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1956/06/24
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,boggd901
@@ -2436,7 +2436,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1956/06/30
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dascf901
@@ -2561,7 +2561,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1956/07/01
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,secof101
@@ -2669,7 +2669,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1956/07/04
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,engeb902
@@ -2777,7 +2777,7 @@ info,hometeam,MLN
 info,site,MIL05
 info,date,1956/07/06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,dixoh901
@@ -2876,7 +2876,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1956/07/07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,donaa901
@@ -2981,7 +2981,7 @@ info,hometeam,MLN
 info,site,MIL05
 info,date,1956/07/08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,pineb101
@@ -3089,7 +3089,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1956/07/13
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,gormt101
@@ -3195,7 +3195,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1956/07/14
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,pineb101
@@ -3295,7 +3295,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1956/07/14
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,boggd901
@@ -3413,7 +3413,7 @@ info,hometeam,MLN
 info,site,MIL05
 info,date,1956/07/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,balll901
@@ -3527,7 +3527,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1956/07/24
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,secof101
@@ -3632,7 +3632,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1956/07/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,engeb902
@@ -3752,7 +3752,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1956/08/03
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,lands901
@@ -3857,7 +3857,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1956/08/04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,pineb101
@@ -3966,7 +3966,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1956/08/05
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,craws901
@@ -4073,7 +4073,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1956/08/05
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,balll901
@@ -4173,7 +4173,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1956/08/11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,craws901
@@ -4290,7 +4290,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1956/08/12
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,balll901
@@ -4391,7 +4391,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1956/08/12
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,boggd901
@@ -4501,7 +4501,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1956/08/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,pineb101
@@ -4603,7 +4603,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1956/08/19
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dixoh901
@@ -4709,7 +4709,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1956/08/19
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,donaa901
@@ -4814,7 +4814,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1956/08/26
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,donaa901
@@ -4915,7 +4915,7 @@ info,hometeam,MLN
 info,site,MIL05
 info,date,1956/08/28
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,goetl901
@@ -5023,7 +5023,7 @@ info,hometeam,MLN
 info,site,MIL05
 info,date,1956/08/29
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,dascf901
@@ -5126,7 +5126,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1956/09/11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,boggd901
@@ -5234,7 +5234,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1956/09/18
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,craws901
@@ -5347,7 +5347,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1956/09/19
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,balll901
@@ -5446,7 +5446,7 @@ info,hometeam,NY1
 info,site,NYC14
 info,date,1956/09/19
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,gorea901

--- a/event/regular/1956.EDA
+++ b/event/regular/1956.EDA
@@ -148,7 +148,7 @@ info,hometeam,KC1
 info,site,KAN05
 info,date,1956/09/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,unknown
 info,usedh,false
 info,umphome,soarh901
@@ -314,7 +314,7 @@ info,hometeam,KC1
 info,site,KAN05
 info,date,1956/09/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,unknown
 info,usedh,false
 info,umphome,papaj901

--- a/event/regular/1956KC1.EVA
+++ b/event/regular/1956KC1.EVA
@@ -2779,7 +2779,7 @@ info,hometeam,KC1
 info,date,1956/05/30
 info,site,KAN05
 info,number,1
-info,starttime,0:00AM
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,tabaf901

--- a/event/regular/1957CIN.EVN
+++ b/event/regular/1957CIN.EVN
@@ -6,7 +6,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1957/04/16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,conlj102
@@ -2409,7 +2409,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1957/05/24
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,boggd901

--- a/event/regular/1957SLN.EVN
+++ b/event/regular/1957SLN.EVN
@@ -6,7 +6,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1957/04/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,donaa901
@@ -341,7 +341,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1957/04/21
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,smitv101
@@ -1643,7 +1643,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1957/05/15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,conlj102
@@ -1988,7 +1988,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1957/05/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,dascf901
@@ -2602,7 +2602,7 @@ info,hometeam,SLN
 info,site,STL07
 info,date,1957/05/27
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,burkk101

--- a/event/regular/1958.EDA
+++ b/event/regular/1958.EDA
@@ -172,7 +172,7 @@ info,hometeam,KC1
 info,site,KAN05
 info,date,1958/05/23
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,unknown
 info,usedh,false
 info,umphome,chyln901
@@ -315,7 +315,7 @@ info,hometeam,KC1
 info,site,KAN05
 info,date,1958/06/21
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,unknown
 info,usedh,false
 info,umphome,mckib901

--- a/event/regular/1958CHN.EVN
+++ b/event/regular/1958CHN.EVN
@@ -5,7 +5,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1958/04/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,craws901

--- a/event/regular/1958CLE.EVA
+++ b/event/regular/1958CLE.EVA
@@ -6114,7 +6114,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1958/07/24
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mckib901

--- a/event/regular/1958KC1.EVA
+++ b/event/regular/1958KC1.EVA
@@ -2923,7 +2923,7 @@ info,hometeam,KC1
 info,site,KAN05
 info,date,1958/05/30
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hurle901
@@ -3210,7 +3210,7 @@ info,hometeam,KC1
 info,site,KAN05
 info,date,1958/05/31
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,tabaf901
@@ -3352,7 +3352,7 @@ info,hometeam,KC1
 info,site,KAN05
 info,date,1958/06/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,papaj901
@@ -8626,7 +8626,7 @@ info,hometeam,KC1
 info,site,KAN05
 info,date,1958/09/01
 info,number,1
-info,starttime,0:00AM
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,umonf901

--- a/event/regular/1959.EDA
+++ b/event/regular/1959.EDA
@@ -5,7 +5,7 @@ info,hometeam,KC1
 info,site,KAN05
 info,date,1959/06/03
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,unknown
 info,usedh,false
 info,umphome,runge901

--- a/event/regular/1962CHN.EVN
+++ b/event/regular/1962CHN.EVN
@@ -12301,7 +12301,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1962/09/28
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,pryop901

--- a/event/regular/1962KC1.EVA
+++ b/event/regular/1962KC1.EVA
@@ -11657,7 +11657,7 @@ info,hometeam,KC1
 info,site,KAN05
 info,date,1962/09/20
 info,number,0
-info,starttime,0:00AM
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,nappl901

--- a/event/regular/1963BOS.EVA
+++ b/event/regular/1963BOS.EVA
@@ -4568,7 +4568,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1963/06/18
 info,number,0
-info,starttime,0:00AM
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,hallb901

--- a/event/regular/1964DET.EVA
+++ b/event/regular/1964DET.EVA
@@ -7640,7 +7640,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1964/07/26
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hurle901

--- a/event/regular/1964LAA.EVA
+++ b/event/regular/1964LAA.EVA
@@ -7467,7 +7467,7 @@ info,hometeam,LAA
 info,site,LOS03
 info,date,1964/07/27
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,umonf901
@@ -7724,7 +7724,7 @@ info,hometeam,LAA
 info,site,LOS03
 info,date,1964/07/29
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,papaj901

--- a/event/regular/1964MIN.EVA
+++ b/event/regular/1964MIN.EVA
@@ -7542,7 +7542,7 @@ info,hometeam,MIN
 info,site,MIN02
 info,date,1964/07/31
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,hurle901
@@ -7687,7 +7687,7 @@ info,hometeam,MIN
 info,site,MIN02
 info,date,1964/08/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,carrh901

--- a/event/regular/1966ATL.EVN
+++ b/event/regular/1966ATL.EVN
@@ -10587,7 +10587,7 @@ info,hometeam,ATL
 info,site,ATL01
 info,date,1966/09/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,engeb901
@@ -10724,7 +10724,7 @@ info,hometeam,ATL
 info,site,ATL01
 info,date,1966/09/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,secof101

--- a/event/regular/1966BAL.EVA
+++ b/event/regular/1966BAL.EVA
@@ -6,7 +6,7 @@ info,hometeam,BAL
 info,site,BAL11
 info,date,1966/04/15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stewb902
@@ -136,7 +136,7 @@ info,hometeam,BAL
 info,site,BAL11
 info,date,1966/04/16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hallb901
@@ -280,7 +280,7 @@ info,hometeam,BAL
 info,site,BAL11
 info,date,1966/04/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,ashfe901
@@ -1269,7 +1269,7 @@ info,hometeam,BAL
 info,site,BAL11
 info,date,1966/05/08
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,drumc901
@@ -5550,7 +5550,7 @@ info,hometeam,BAL
 info,site,BAL11
 info,date,1966/07/02
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dimul901
@@ -5837,7 +5837,7 @@ info,hometeam,BAL
 info,site,BAL11
 info,date,1966/07/03
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,flahr901
@@ -6604,7 +6604,7 @@ info,hometeam,BAL
 info,site,BAL11
 info,date,1966/07/09
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stevj901
@@ -6916,7 +6916,7 @@ info,hometeam,BAL
 info,site,BAL11
 info,date,1966/07/10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hallb901
@@ -7805,7 +7805,7 @@ info,hometeam,BAL
 info,site,BAL11
 info,date,1966/07/24
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,kinnb901

--- a/event/regular/1966BOS.EVA
+++ b/event/regular/1966BOS.EVA
@@ -6,7 +6,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1966/04/12
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,flahr901
@@ -217,7 +217,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1966/04/13
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,runge901

--- a/event/regular/1966CAL.EVA
+++ b/event/regular/1966CAL.EVA
@@ -6387,7 +6387,7 @@ info,hometeam,CAL
 info,site,ANA01
 info,date,1966/06/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stevj901

--- a/event/regular/1966CHA.EVA
+++ b/event/regular/1966CHA.EVA
@@ -6464,7 +6464,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1966/07/17
 info,number,1
-info,starttime,0:00AM
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hallb901

--- a/event/regular/1966DET.EVA
+++ b/event/regular/1966DET.EVA
@@ -919,7 +919,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1966/04/30
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dimul901
@@ -1060,7 +1060,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1966/05/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,soarh901

--- a/event/regular/1966KC1.EVA
+++ b/event/regular/1966KC1.EVA
@@ -5338,7 +5338,7 @@ info,hometeam,KC1
 info,site,KAN05
 info,date,1966/06/30
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,valeb901

--- a/event/regular/1966MIN.EVA
+++ b/event/regular/1966MIN.EVA
@@ -7561,7 +7561,7 @@ info,hometeam,MIN
 info,site,MIN02
 info,date,1966/07/31
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,flahr901

--- a/event/regular/1966NYA.EVA
+++ b/event/regular/1966NYA.EVA
@@ -451,7 +451,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1966/04/23
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,odomj901
@@ -609,7 +609,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1966/04/24
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,nappl901
@@ -4523,7 +4523,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1966/06/23
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,chyln901

--- a/event/regular/1967ATL.EVN
+++ b/event/regular/1967ATL.EVN
@@ -9188,7 +9188,7 @@ info,hometeam,ATL
 info,site,ATL01
 info,date,1967/08/31
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,weyel901
@@ -9339,7 +9339,7 @@ info,hometeam,ATL
 info,site,ATL01
 info,date,1967/09/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,wendh901
@@ -9495,7 +9495,7 @@ info,hometeam,ATL
 info,site,ATL01
 info,date,1967/09/02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,jackb901
@@ -9640,7 +9640,7 @@ info,hometeam,ATL
 info,site,ATL01
 info,date,1967/09/03
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,sudoe901
@@ -11271,7 +11271,7 @@ info,hometeam,ATL
 info,site,ATL01
 info,date,1967/09/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,lands901
@@ -11406,7 +11406,7 @@ info,hometeam,ATL
 info,site,ATL01
 info,date,1967/09/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,barla901

--- a/event/regular/1967BAL.EVA
+++ b/event/regular/1967BAL.EVA
@@ -5,7 +5,7 @@ info,hometeam,BAL
 info,site,BAL11
 info,date,1967/04/11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,honoj901
@@ -153,7 +153,7 @@ info,hometeam,BAL
 info,site,BAL11
 info,date,1967/04/13
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,chyln901
@@ -285,7 +285,7 @@ info,hometeam,BAL
 info,site,BAL11
 info,date,1967/04/21
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,salea901
@@ -432,7 +432,7 @@ info,hometeam,BAL
 info,site,BAL11
 info,date,1967/04/22
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,odomj901
@@ -596,7 +596,7 @@ info,hometeam,BAL
 info,site,BAL11
 info,date,1967/04/23
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,soarh901
@@ -753,7 +753,7 @@ info,hometeam,BAL
 info,site,BAL11
 info,date,1967/04/23
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,salea901
@@ -929,7 +929,7 @@ info,hometeam,BAL
 info,site,BAL11
 info,date,1967/04/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,flahr901
@@ -1058,7 +1058,7 @@ info,hometeam,BAL
 info,site,BAL11
 info,date,1967/04/28
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,stevj901
@@ -1209,7 +1209,7 @@ info,hometeam,BAL
 info,site,BAL11
 info,date,1967/04/29
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stewb902
@@ -1361,7 +1361,7 @@ info,hometeam,BAL
 info,site,BAL11
 info,date,1967/04/30
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,valeb901
@@ -1509,7 +1509,7 @@ info,hometeam,BAL
 info,site,BAL11
 info,date,1967/04/30
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,sprim901
@@ -1659,7 +1659,7 @@ info,hometeam,BAL
 info,site,BAL11
 info,date,1967/05/09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,stewb902
@@ -1804,7 +1804,7 @@ info,hometeam,BAL
 info,site,BAL11
 info,date,1967/05/10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,valeb901
@@ -2819,7 +2819,7 @@ info,hometeam,BAL
 info,site,BAL11
 info,date,1967/05/30
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hallb901
@@ -2959,7 +2959,7 @@ info,hometeam,BAL
 info,site,BAL11
 info,date,1967/05/30
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,honoj901
@@ -3089,7 +3089,7 @@ info,hometeam,BAL
 info,site,BAL11
 info,date,1967/06/02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,stewb902
@@ -3247,7 +3247,7 @@ info,hometeam,BAL
 info,site,BAL11
 info,date,1967/06/03
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,valeb901
@@ -3416,7 +3416,7 @@ info,hometeam,BAL
 info,site,BAL11
 info,date,1967/06/04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,sprim901
@@ -3673,7 +3673,7 @@ info,hometeam,BAL
 info,site,BAL11
 info,date,1967/06/16
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,umonf901
@@ -3815,7 +3815,7 @@ info,hometeam,BAL
 info,site,BAL11
 info,date,1967/06/16
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,kinnb901
@@ -3952,7 +3952,7 @@ info,hometeam,BAL
 info,site,BAL11
 info,date,1967/06/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,neudj901
@@ -4097,7 +4097,7 @@ info,hometeam,BAL
 info,site,BAL11
 info,date,1967/06/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,nappl901
@@ -4237,7 +4237,7 @@ info,hometeam,BAL
 info,site,BAL11
 info,date,1967/06/19
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,salea901
@@ -4365,7 +4365,7 @@ info,hometeam,BAL
 info,site,BAL11
 info,date,1967/06/19
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,odomj901
@@ -4689,7 +4689,7 @@ info,hometeam,BAL
 info,site,BAL11
 info,date,1967/06/24
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,kinnb901
@@ -4836,7 +4836,7 @@ info,hometeam,BAL
 info,site,BAL11
 info,date,1967/06/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,drumc901
@@ -4994,7 +4994,7 @@ info,hometeam,BAL
 info,site,BAL11
 info,date,1967/06/27
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,hallb901
@@ -5146,7 +5146,7 @@ info,hometeam,BAL
 info,site,BAL11
 info,date,1967/06/28
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,honoj901
@@ -5310,7 +5310,7 @@ info,hometeam,BAL
 info,site,BAL11
 info,date,1967/06/29
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,chyln901
@@ -5440,7 +5440,7 @@ info,hometeam,BAL
 info,site,BAL11
 info,date,1967/06/30
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,drumc901
@@ -5660,7 +5660,7 @@ info,hometeam,BAL
 info,site,BAL11
 info,date,1967/06/30
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,hallb901
@@ -5815,7 +5815,7 @@ info,hometeam,BAL
 info,site,BAL11
 info,date,1967/07/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,honoj901
@@ -5963,7 +5963,7 @@ info,hometeam,BAL
 info,site,BAL11
 info,date,1967/07/02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,chyln901
@@ -6646,7 +6646,7 @@ info,hometeam,BAL
 info,site,BAL11
 info,date,1967/07/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,ricej901
@@ -6791,7 +6791,7 @@ info,hometeam,BAL
 info,site,BAL11
 info,date,1967/07/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,dimul901
@@ -6927,7 +6927,7 @@ info,hometeam,BAL
 info,site,BAL11
 info,date,1967/07/21
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,ashfe901
@@ -7076,7 +7076,7 @@ info,hometeam,BAL
 info,site,BAL11
 info,date,1967/07/21
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,flahr901
@@ -7219,7 +7219,7 @@ info,hometeam,BAL
 info,site,BAL11
 info,date,1967/07/22
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,ricej901
@@ -8356,7 +8356,7 @@ info,hometeam,BAL
 info,site,BAL11
 info,date,1967/08/07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,ricej901
@@ -8476,7 +8476,7 @@ info,hometeam,BAL
 info,site,BAL11
 info,date,1967/08/08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,ashfe901
@@ -8643,7 +8643,7 @@ info,hometeam,BAL
 info,site,BAL11
 info,date,1967/08/09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,flahr901
@@ -9316,7 +9316,7 @@ info,hometeam,BAL
 info,site,BAL11
 info,date,1967/08/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,odomj901
@@ -9470,7 +9470,7 @@ info,hometeam,BAL
 info,site,BAL11
 info,date,1967/09/07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,nappl901
@@ -9599,7 +9599,7 @@ info,hometeam,BAL
 info,site,BAL11
 info,date,1967/09/08
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,umonf901
@@ -9748,7 +9748,7 @@ info,hometeam,BAL
 info,site,BAL11
 info,date,1967/09/08
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,valeb901
@@ -9902,7 +9902,7 @@ info,hometeam,BAL
 info,site,BAL11
 info,date,1967/09/09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,kinnb901
@@ -10044,7 +10044,7 @@ info,hometeam,BAL
 info,site,BAL11
 info,date,1967/09/10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,nappl901
@@ -10478,7 +10478,7 @@ info,hometeam,BAL
 info,site,BAL11
 info,date,1967/09/22
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,umonf901
@@ -10618,7 +10618,7 @@ info,hometeam,BAL
 info,site,BAL11
 info,date,1967/09/22
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,valeb901
@@ -10775,7 +10775,7 @@ info,hometeam,BAL
 info,site,BAL11
 info,date,1967/09/23
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,kinnb901
@@ -10925,7 +10925,7 @@ info,hometeam,BAL
 info,site,BAL11
 info,date,1967/09/24
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,nappl901
@@ -11105,7 +11105,7 @@ info,hometeam,BAL
 info,site,BAL11
 info,date,1967/09/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,flahr901
@@ -11257,7 +11257,7 @@ info,hometeam,BAL
 info,site,BAL11
 info,date,1967/09/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,salea901

--- a/event/regular/1967BOS.EVA
+++ b/event/regular/1967BOS.EVA
@@ -2159,7 +2159,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1967/05/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,stevj901
@@ -3498,7 +3498,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1967/06/09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,nappl901
@@ -3642,7 +3642,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1967/06/10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,umonf901
@@ -3787,7 +3787,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1967/06/11
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,kinnb901
@@ -3936,7 +3936,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1967/06/11
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,neudj901
@@ -4701,7 +4701,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1967/06/15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,nappl901
@@ -4868,7 +4868,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1967/06/23
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,soarh901
@@ -5030,7 +5030,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1967/06/24
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,salea901
@@ -5178,7 +5178,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1967/06/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,odomj901
@@ -5321,7 +5321,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1967/07/13
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,chyln901
@@ -5462,7 +5462,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1967/07/13
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,drumc901
@@ -5604,7 +5604,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1967/07/14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,hallb901
@@ -5764,7 +5764,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1967/07/15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,honoj901
@@ -6191,7 +6191,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1967/07/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,chyln901
@@ -6361,7 +6361,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1967/07/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,drumc901
@@ -6529,7 +6529,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1967/07/27
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hallb901
@@ -6697,7 +6697,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1967/07/28
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,honoj901
@@ -6852,7 +6852,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1967/07/29
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,chyln901
@@ -7006,7 +7006,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1967/07/29
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,drumc901
@@ -7160,7 +7160,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1967/07/30
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hallb901
@@ -7322,7 +7322,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1967/07/31
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,honoj901
@@ -8716,7 +8716,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1967/08/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,kinnb901
@@ -8902,7 +8902,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1967/08/20
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,nappl901
@@ -9075,7 +9075,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1967/08/20
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,umonf901
@@ -9265,7 +9265,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1967/08/21
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,hallb901
@@ -9414,7 +9414,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1967/08/22
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,odomj901
@@ -9556,7 +9556,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1967/08/22
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,soarh901
@@ -9694,7 +9694,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1967/08/23
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,runge901
@@ -9847,7 +9847,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1967/08/24
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hallb901
@@ -11470,7 +11470,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1967/09/15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,neudj901
@@ -11623,7 +11623,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1967/09/16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stevj901
@@ -11758,7 +11758,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1967/09/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stewb902
@@ -11913,7 +11913,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1967/09/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,chyln901
@@ -12057,7 +12057,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1967/09/27
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,drumc901
@@ -12204,7 +12204,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1967/09/30
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,honoj901
@@ -12356,7 +12356,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1967/10/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,chyln901

--- a/event/regular/1967CAL.EVA
+++ b/event/regular/1967CAL.EVA
@@ -5,7 +5,7 @@ info,hometeam,CAL
 info,site,ANA01
 info,date,1967/04/11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,flahr901
@@ -135,7 +135,7 @@ info,hometeam,CAL
 info,site,ANA01
 info,date,1967/04/12
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,ricej901
@@ -303,7 +303,7 @@ info,hometeam,CAL
 info,site,ANA01
 info,date,1967/04/14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,dimul901
@@ -443,7 +443,7 @@ info,hometeam,CAL
 info,site,ANA01
 info,date,1967/04/15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,ashfe901
@@ -613,7 +613,7 @@ info,hometeam,CAL
 info,site,ANA01
 info,date,1967/04/16
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,ashfe901
@@ -753,7 +753,7 @@ info,hometeam,CAL
 info,site,ANA01
 info,date,1967/04/16
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,flahr901
@@ -885,7 +885,7 @@ info,hometeam,CAL
 info,site,ANA01
 info,date,1967/05/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,hallb901
@@ -1024,7 +1024,7 @@ info,hometeam,CAL
 info,site,ANA01
 info,date,1967/05/02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,honoj901
@@ -1148,7 +1148,7 @@ info,hometeam,CAL
 info,site,ANA01
 info,date,1967/05/03
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,chyln901
@@ -1286,7 +1286,7 @@ info,hometeam,CAL
 info,site,ANA01
 info,date,1967/05/05
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,drumc901
@@ -1417,7 +1417,7 @@ info,hometeam,CAL
 info,site,ANA01
 info,date,1967/05/06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,hallb901
@@ -1567,7 +1567,7 @@ info,hometeam,CAL
 info,site,ANA01
 info,date,1967/05/07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,honoj901
@@ -1693,7 +1693,7 @@ info,hometeam,CAL
 info,site,ANA01
 info,date,1967/05/08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,chyln901
@@ -1842,7 +1842,7 @@ info,hometeam,CAL
 info,site,ANA01
 info,date,1967/05/09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,drumc901
@@ -1971,7 +1971,7 @@ info,hometeam,CAL
 info,site,ANA01
 info,date,1967/05/10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,hallb901
@@ -2112,7 +2112,7 @@ info,hometeam,CAL
 info,site,ANA01
 info,date,1967/05/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,nappl901
@@ -2253,7 +2253,7 @@ info,hometeam,CAL
 info,site,ANA01
 info,date,1967/05/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,umonf901
@@ -2402,7 +2402,7 @@ info,hometeam,CAL
 info,site,ANA01
 info,date,1967/05/21
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,kinnb901
@@ -2858,7 +2858,7 @@ info,hometeam,CAL
 info,site,ANA01
 info,date,1967/05/26
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,umonf901
@@ -2997,7 +2997,7 @@ info,hometeam,CAL
 info,site,ANA01
 info,date,1967/05/26
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,kinnb901
@@ -3149,7 +3149,7 @@ info,hometeam,CAL
 info,site,ANA01
 info,date,1967/05/27
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,neudj901
@@ -3273,7 +3273,7 @@ info,hometeam,CAL
 info,site,ANA01
 info,date,1967/05/28
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,nappl901
@@ -3417,7 +3417,7 @@ info,hometeam,CAL
 info,site,ANA01
 info,date,1967/06/05
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,soarh901
@@ -3549,7 +3549,7 @@ info,hometeam,CAL
 info,site,ANA01
 info,date,1967/06/06
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,soarh901
@@ -3725,7 +3725,7 @@ info,hometeam,CAL
 info,site,ANA01
 info,date,1967/06/06
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,soarh901
@@ -3880,7 +3880,7 @@ info,hometeam,CAL
 info,site,ANA01
 info,date,1967/06/07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,salea901
@@ -4005,7 +4005,7 @@ info,hometeam,CAL
 info,site,ANA01
 info,date,1967/06/08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,odomj901
@@ -4559,7 +4559,7 @@ info,hometeam,CAL
 info,site,ANA01
 info,date,1967/06/12
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,odomj901
@@ -4767,7 +4767,7 @@ info,hometeam,CAL
 info,site,ANA01
 info,date,1967/06/13
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,runge901
@@ -4904,7 +4904,7 @@ info,hometeam,CAL
 info,site,ANA01
 info,date,1967/06/13
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,soarh901
@@ -5046,7 +5046,7 @@ info,hometeam,CAL
 info,site,ANA01
 info,date,1967/06/14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,salea901
@@ -5184,7 +5184,7 @@ info,hometeam,CAL
 info,site,ANA01
 info,date,1967/06/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,stevj901
@@ -5343,7 +5343,7 @@ info,hometeam,CAL
 info,site,ANA01
 info,date,1967/06/27
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,stewb902
@@ -5511,7 +5511,7 @@ info,hometeam,CAL
 info,site,ANA01
 info,date,1967/06/28
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,valeb901
@@ -6114,7 +6114,7 @@ info,hometeam,CAL
 info,site,ANA01
 info,date,1967/07/03
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,ashfe901
@@ -6277,7 +6277,7 @@ info,hometeam,CAL
 info,site,ANA01
 info,date,1967/07/04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,flahr901
@@ -6427,7 +6427,7 @@ info,hometeam,CAL
 info,site,ANA01
 info,date,1967/07/05
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,dimul901
@@ -7409,7 +7409,7 @@ info,hometeam,CAL
 info,site,ANA01
 info,date,1967/07/21
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,kinnb901
@@ -7543,7 +7543,7 @@ info,hometeam,CAL
 info,site,ANA01
 info,date,1967/07/22
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,neudj901
@@ -7681,7 +7681,7 @@ info,hometeam,CAL
 info,site,ANA01
 info,date,1967/07/23
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,nappl901
@@ -7817,7 +7817,7 @@ info,hometeam,CAL
 info,site,ANA01
 info,date,1967/08/04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,hallb901
@@ -7956,7 +7956,7 @@ info,hometeam,CAL
 info,site,ANA01
 info,date,1967/08/05
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,honoj901
@@ -8121,7 +8121,7 @@ info,hometeam,CAL
 info,site,ANA01
 info,date,1967/08/06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,chyln901
@@ -8739,7 +8739,7 @@ info,hometeam,CAL
 info,site,ANA01
 info,date,1967/08/11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,soarh901
@@ -8858,7 +8858,7 @@ info,hometeam,CAL
 info,site,ANA01
 info,date,1967/08/12
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,runge901
@@ -8988,7 +8988,7 @@ info,hometeam,CAL
 info,site,ANA01
 info,date,1967/08/13
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hallb901
@@ -9132,7 +9132,7 @@ info,hometeam,CAL
 info,site,ANA01
 info,date,1967/08/14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,odomj901
@@ -9282,7 +9282,7 @@ info,hometeam,CAL
 info,site,ANA01
 info,date,1967/08/15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,soarh901
@@ -9429,7 +9429,7 @@ info,hometeam,CAL
 info,site,ANA01
 info,date,1967/08/16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,runge901
@@ -10164,7 +10164,7 @@ info,hometeam,CAL
 info,site,ANA01
 info,date,1967/09/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,stewb902
@@ -10331,7 +10331,7 @@ info,hometeam,CAL
 info,site,ANA01
 info,date,1967/09/02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,dimul901
@@ -10491,7 +10491,7 @@ info,hometeam,CAL
 info,site,ANA01
 info,date,1967/09/03
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,neudj901
@@ -10639,7 +10639,7 @@ info,hometeam,CAL
 info,site,ANA01
 info,date,1967/09/04
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stevj901
@@ -10773,7 +10773,7 @@ info,hometeam,CAL
 info,site,ANA01
 info,date,1967/09/04
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stewb902
@@ -10962,7 +10962,7 @@ info,hometeam,CAL
 info,site,ANA01
 info,date,1967/09/05
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dimul901
@@ -11105,7 +11105,7 @@ info,hometeam,CAL
 info,site,ANA01
 info,date,1967/09/05
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,neudj901

--- a/event/regular/1967CHA.EVA
+++ b/event/regular/1967CHA.EVA
@@ -5,7 +5,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1967/04/15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,valeb901
@@ -163,7 +163,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1967/04/16
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,sprim901
@@ -303,7 +303,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1967/04/16
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stevj901
@@ -805,7 +805,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1967/04/28
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,honoj901
@@ -947,7 +947,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1967/04/30
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,chyln901
@@ -1079,7 +1079,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1967/04/30
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,drumc901
@@ -1396,7 +1396,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1967/05/12
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,odomj901
@@ -1536,7 +1536,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1967/05/13
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,soarh901
@@ -1672,7 +1672,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1967/05/14
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,soarh901
@@ -1813,7 +1813,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1967/05/14
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,salea901
@@ -1944,7 +1944,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1967/05/16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,kinnb901
@@ -2070,7 +2070,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1967/05/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,neudj901
@@ -2221,7 +2221,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1967/05/31
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,chyln901
@@ -3055,7 +3055,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1967/06/06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,stevj901
@@ -3219,7 +3219,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1967/06/08
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stewb902
@@ -3344,7 +3344,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1967/06/08
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,valeb901
@@ -3904,7 +3904,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1967/06/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,valeb901
@@ -4061,7 +4061,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1967/06/21
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,sprim901
@@ -4210,7 +4210,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1967/06/21
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,stevj901
@@ -4359,7 +4359,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1967/07/03
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,salea901
@@ -4560,7 +4560,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1967/07/04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,odomj901
@@ -4681,7 +4681,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1967/07/05
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,ricej901
@@ -4859,7 +4859,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1967/07/06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,soarh901
@@ -5000,7 +5000,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1967/07/07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,salea901
@@ -5144,7 +5144,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1967/07/08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,odomj901
@@ -5271,7 +5271,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1967/07/09
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,ricej901
@@ -5442,7 +5442,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1967/07/09
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,soarh901
@@ -12197,7 +12197,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1967/09/29
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,stewb902
@@ -12337,7 +12337,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1967/09/30
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dimul901
@@ -12472,7 +12472,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1967/10/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stevj901

--- a/event/regular/1967CHN.EVN
+++ b/event/regular/1967CHN.EVN
@@ -8535,7 +8535,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1967/08/07
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,kiblj901
@@ -9015,7 +9015,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1967/08/09
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,harvd901
@@ -10212,7 +10212,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1967/08/30
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,pryop901
@@ -11519,7 +11519,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1967/09/04
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,burkk101
@@ -12029,7 +12029,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1967/09/22
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,venzt901

--- a/event/regular/1967CIN.EVN
+++ b/event/regular/1967CIN.EVN
@@ -7737,7 +7737,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1967/07/30
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,varge901
@@ -8585,7 +8585,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1967/08/10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,kiblj901
@@ -8737,7 +8737,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1967/08/11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,craws901
@@ -8897,7 +8897,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1967/08/12
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,pelec901
@@ -9029,7 +9029,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1967/08/13
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,harvd901
@@ -10493,7 +10493,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1967/09/12
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,burkk101
@@ -11236,7 +11236,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1967/09/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,dezef901
@@ -11392,7 +11392,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1967/09/28
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,sudoe901
@@ -11533,7 +11533,7 @@ info,hometeam,CIN
 info,site,CIN07
 info,date,1967/09/28
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,wendh901

--- a/event/regular/1967CLE.EVA
+++ b/event/regular/1967CLE.EVA
@@ -283,7 +283,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1967/04/21
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,hallb901
@@ -447,7 +447,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1967/04/22
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,honoj901
@@ -604,7 +604,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1967/04/23
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,chyln901
@@ -810,7 +810,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1967/04/23
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,drumc901
@@ -985,7 +985,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1967/04/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,neudj901
@@ -1100,7 +1100,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1967/04/27
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,nappl901
@@ -1252,7 +1252,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1967/05/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,odomj901
@@ -1441,7 +1441,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1967/05/03
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,soarh901
@@ -1582,7 +1582,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1967/05/05
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,salea901
@@ -1715,7 +1715,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1967/05/06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,odomj901
@@ -2152,7 +2152,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1967/05/22
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,stewb902
@@ -2291,7 +2291,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1967/05/23
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,valeb901
@@ -2437,7 +2437,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1967/05/24
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,sprim901
@@ -2581,7 +2581,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1967/05/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,stevj901
@@ -3432,7 +3432,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1967/06/04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,flahr901
@@ -3571,7 +3571,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1967/06/16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,drumc901
@@ -3725,7 +3725,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1967/06/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,hallb901
@@ -3865,7 +3865,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1967/06/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,honoj901
@@ -4424,7 +4424,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1967/06/22
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,nappl901
@@ -5007,7 +5007,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1967/07/07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,kinnb901
@@ -5152,7 +5152,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1967/07/08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,neudj901
@@ -5329,7 +5329,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1967/07/09
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,nappl901
@@ -5504,7 +5504,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1967/07/09
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,umonf901
@@ -6079,7 +6079,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1967/07/21
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,chyln901
@@ -6230,7 +6230,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1967/07/22
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,drumc901
@@ -6359,7 +6359,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1967/07/23
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,drumc901
@@ -6522,7 +6522,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1967/07/23
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hallb901
@@ -6654,7 +6654,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1967/07/28
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,kinnb901
@@ -6800,7 +6800,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1967/07/29
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,neudj901
@@ -6959,7 +6959,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1967/07/30
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,umonf901
@@ -7101,7 +7101,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1967/07/30
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,kinnb901
@@ -8366,7 +8366,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1967/08/10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,ricej901
@@ -9137,7 +9137,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1967/08/21
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,dimul901
@@ -9294,7 +9294,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1967/08/22
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,neudj901
@@ -9420,7 +9420,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1967/08/23
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,stevj901
@@ -9599,7 +9599,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1967/08/24
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,stewb902
@@ -9730,7 +9730,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1967/08/25
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,kinnb901
@@ -9908,7 +9908,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1967/08/25
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,nappl901
@@ -10041,7 +10041,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1967/08/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,umonf901
@@ -10181,7 +10181,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1967/08/27
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,valeb901
@@ -10884,7 +10884,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1967/09/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,kinnb901
@@ -11008,7 +11008,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1967/09/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,honoj901
@@ -11157,7 +11157,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1967/09/21
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,chyln901
@@ -11840,7 +11840,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1967/09/30
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,ricej901
@@ -11975,7 +11975,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1967/10/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,ashfe901

--- a/event/regular/1967DET.EVA
+++ b/event/regular/1967DET.EVA
@@ -5,7 +5,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1967/04/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stewb902
@@ -133,7 +133,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1967/04/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,valeb901
@@ -844,7 +844,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1967/05/05
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,umonf901
@@ -975,7 +975,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1967/05/06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,kinnb901
@@ -1111,7 +1111,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1967/05/07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,neudj901
@@ -2276,7 +2276,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1967/05/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,chyln901
@@ -2443,7 +2443,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1967/05/27
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,drumc901
@@ -2605,7 +2605,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1967/05/28
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,sprim901
@@ -6284,7 +6284,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1967/07/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,runge901
@@ -6423,7 +6423,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1967/07/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,soarh901
@@ -6572,7 +6572,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1967/07/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,salea901
@@ -10964,7 +10964,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1967/09/15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,sprim901
@@ -11144,7 +11144,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1967/09/16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,honoj901
@@ -11319,7 +11319,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1967/09/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,chyln901

--- a/event/regular/1967HOU.EVN
+++ b/event/regular/1967HOU.EVN
@@ -8550,7 +8550,7 @@ info,hometeam,HOU
 info,site,HOU02
 info,date,1967/08/15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,sudoe901
@@ -8741,7 +8741,7 @@ info,hometeam,HOU
 info,site,HOU02
 info,date,1967/08/16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,weyel901
@@ -8885,7 +8885,7 @@ info,hometeam,HOU
 info,site,HOU02
 info,date,1967/08/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,wendh901
@@ -10097,7 +10097,7 @@ info,hometeam,HOU
 info,site,HOU02
 info,date,1967/08/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,gormt101
@@ -10234,7 +10234,7 @@ info,hometeam,HOU
 info,site,HOU02
 info,date,1967/08/26
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,venzt901
@@ -10378,7 +10378,7 @@ info,hometeam,HOU
 info,site,HOU02
 info,date,1967/08/26
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,pryop901
@@ -10524,7 +10524,7 @@ info,hometeam,HOU
 info,site,HOU02
 info,date,1967/08/27
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,engeb901

--- a/event/regular/1967KC1.EVA
+++ b/event/regular/1967KC1.EVA
@@ -176,7 +176,7 @@ info,hometeam,KC1
 info,site,KAN05
 info,date,1967/04/14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,umonf901
@@ -321,7 +321,7 @@ info,hometeam,KC1
 info,site,KAN05
 info,date,1967/04/15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,kinnb901
@@ -817,7 +817,7 @@ info,hometeam,KC1
 info,site,KAN05
 info,date,1967/05/02
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,dimul901
@@ -964,7 +964,7 @@ info,hometeam,KC1
 info,site,KAN05
 info,date,1967/05/02
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,ashfe901
@@ -1106,7 +1106,7 @@ info,hometeam,KC1
 info,site,KAN05
 info,date,1967/05/03
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,flahr901
@@ -7087,7 +7087,7 @@ info,hometeam,KC1
 info,site,KAN05
 info,date,1967/07/04
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,valeb901
@@ -7235,7 +7235,7 @@ info,hometeam,KC1
 info,site,KAN05
 info,date,1967/07/04
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,sprim901
@@ -7374,7 +7374,7 @@ info,hometeam,KC1
 info,site,KAN05
 info,date,1967/07/05
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,stevj901
@@ -9493,7 +9493,7 @@ info,hometeam,KC1
 info,site,KAN05
 info,date,1967/08/11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,chyln901
@@ -9654,7 +9654,7 @@ info,hometeam,KC1
 info,site,KAN05
 info,date,1967/08/12
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,drumc901
@@ -9842,7 +9842,7 @@ info,hometeam,KC1
 info,site,KAN05
 info,date,1967/08/13
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,sprim901

--- a/event/regular/1967LAN.EVN
+++ b/event/regular/1967LAN.EVN
@@ -5903,7 +5903,7 @@ info,hometeam,LAN
 info,site,LOS03
 info,date,1967/07/16
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,craws901
@@ -6207,7 +6207,7 @@ info,hometeam,LAN
 info,site,LOS03
 info,date,1967/07/24
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,sudoe901
@@ -6360,7 +6360,7 @@ info,hometeam,LAN
 info,site,LOS03
 info,date,1967/07/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,weyel901
@@ -6492,7 +6492,7 @@ info,hometeam,LAN
 info,site,LOS03
 info,date,1967/07/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,wendh901
@@ -7734,7 +7734,7 @@ info,hometeam,LAN
 info,site,LOS03
 info,date,1967/08/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,harvd901
@@ -7869,7 +7869,7 @@ info,hometeam,LAN
 info,site,LOS03
 info,date,1967/08/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,kiblj901
@@ -8021,7 +8021,7 @@ info,hometeam,LAN
 info,site,LOS03
 info,date,1967/08/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,craws901
@@ -8167,7 +8167,7 @@ info,hometeam,LAN
 info,site,LOS03
 info,date,1967/08/21
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,pelec901
@@ -8293,7 +8293,7 @@ info,hometeam,LAN
 info,site,LOS03
 info,date,1967/08/22
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,steim901
@@ -8438,7 +8438,7 @@ info,hometeam,LAN
 info,site,LOS03
 info,date,1967/08/23
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,donaa901
@@ -8581,7 +8581,7 @@ info,hometeam,LAN
 info,site,LOS03
 info,date,1967/08/24
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,lands901
@@ -9703,7 +9703,7 @@ info,hometeam,LAN
 info,site,LOS03
 info,date,1967/09/08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,sudoe901
@@ -9836,7 +9836,7 @@ info,hometeam,LAN
 info,site,LOS03
 info,date,1967/09/09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,weyel901
@@ -9973,7 +9973,7 @@ info,hometeam,LAN
 info,site,LOS03
 info,date,1967/09/10
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,wendh901
@@ -10119,7 +10119,7 @@ info,hometeam,LAN
 info,site,LOS03
 info,date,1967/09/10
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,jackb901
@@ -11156,7 +11156,7 @@ info,hometeam,LAN
 info,site,LOS03
 info,date,1967/09/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,steim901
@@ -11311,7 +11311,7 @@ info,hometeam,LAN
 info,site,LOS03
 info,date,1967/09/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,craws901

--- a/event/regular/1967MIN.EVA
+++ b/event/regular/1967MIN.EVA
@@ -310,7 +310,7 @@ info,hometeam,MIN
 info,site,MIN02
 info,date,1967/04/16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,soarh901
@@ -450,7 +450,7 @@ info,hometeam,MIN
 info,site,MIN02
 info,date,1967/04/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,runge901
@@ -1336,7 +1336,7 @@ info,hometeam,MIN
 info,site,MIN02
 info,date,1967/05/08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,nappl901
@@ -1502,7 +1502,7 @@ info,hometeam,MIN
 info,site,MIN02
 info,date,1967/05/09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,umonf901
@@ -2227,7 +2227,7 @@ info,hometeam,MIN
 info,site,MIN02
 info,date,1967/05/22
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,ashfe901
@@ -2400,7 +2400,7 @@ info,hometeam,MIN
 info,site,MIN02
 info,date,1967/05/23
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,flahr901
@@ -2548,7 +2548,7 @@ info,hometeam,MIN
 info,site,MIN02
 info,date,1967/05/24
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,ricej901
@@ -2708,7 +2708,7 @@ info,hometeam,MIN
 info,site,MIN02
 info,date,1967/06/02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,drumc901
@@ -2844,7 +2844,7 @@ info,hometeam,MIN
 info,site,MIN02
 info,date,1967/06/03
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hallb901
@@ -3023,7 +3023,7 @@ info,hometeam,MIN
 info,site,MIN02
 info,date,1967/06/04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,honoj901
@@ -3183,7 +3183,7 @@ info,hometeam,MIN
 info,site,MIN02
 info,date,1967/06/05
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,nappl901
@@ -3360,7 +3360,7 @@ info,hometeam,MIN
 info,site,MIN02
 info,date,1967/06/06
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,umonf901
@@ -3525,7 +3525,7 @@ info,hometeam,MIN
 info,site,MIN02
 info,date,1967/06/06
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,kinnb901
@@ -3668,7 +3668,7 @@ info,hometeam,MIN
 info,site,MIN02
 info,date,1967/06/08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,neudj901
@@ -3839,7 +3839,7 @@ info,hometeam,MIN
 info,site,MIN02
 info,date,1967/06/09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,sprim901
@@ -4000,7 +4000,7 @@ info,hometeam,MIN
 info,site,MIN02
 info,date,1967/06/10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,stevj901
@@ -4129,7 +4129,7 @@ info,hometeam,MIN
 info,site,MIN02
 info,date,1967/06/11
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stewb902
@@ -4267,7 +4267,7 @@ info,hometeam,MIN
 info,site,MIN02
 info,date,1967/06/11
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,valeb901
@@ -5049,7 +5049,7 @@ info,hometeam,MIN
 info,site,MIN02
 info,date,1967/06/23
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,ricej901
@@ -5168,7 +5168,7 @@ info,hometeam,MIN
 info,site,MIN02
 info,date,1967/06/24
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dimul901
@@ -5314,7 +5314,7 @@ info,hometeam,MIN
 info,site,MIN02
 info,date,1967/06/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,ashfe901
@@ -5445,7 +5445,7 @@ info,hometeam,MIN
 info,site,MIN02
 info,date,1967/06/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,runge901
@@ -5577,7 +5577,7 @@ info,hometeam,MIN
 info,site,MIN02
 info,date,1967/06/27
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,soarh901
@@ -5706,7 +5706,7 @@ info,hometeam,MIN
 info,site,MIN02
 info,date,1967/06/28
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,salea901
@@ -5829,7 +5829,7 @@ info,hometeam,MIN
 info,site,MIN02
 info,date,1967/07/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,odomj901
@@ -5983,7 +5983,7 @@ info,hometeam,MIN
 info,site,MIN02
 info,date,1967/07/02
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,runge901
@@ -6128,7 +6128,7 @@ info,hometeam,MIN
 info,site,MIN02
 info,date,1967/07/02
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,soarh901
@@ -7322,7 +7322,7 @@ info,hometeam,MIN
 info,site,MIN02
 info,date,1967/07/16
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stewb902
@@ -7457,7 +7457,7 @@ info,hometeam,MIN
 info,site,MIN02
 info,date,1967/07/16
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,valeb901
@@ -7631,7 +7631,7 @@ info,hometeam,MIN
 info,site,MIN02
 info,date,1967/07/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,sprim901
@@ -7765,7 +7765,7 @@ info,hometeam,MIN
 info,site,MIN02
 info,date,1967/08/04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,salea901
@@ -7908,7 +7908,7 @@ info,hometeam,MIN
 info,site,MIN02
 info,date,1967/08/05
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,runge901
@@ -8039,7 +8039,7 @@ info,hometeam,MIN
 info,site,MIN02
 info,date,1967/08/06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,odomj901
@@ -8123,7 +8123,7 @@ info,hometeam,MIN
 info,site,MIN02
 info,date,1967/08/07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,soarh901
@@ -8261,7 +8261,7 @@ info,hometeam,MIN
 info,site,MIN02
 info,date,1967/08/08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,salea901
@@ -8412,7 +8412,7 @@ info,hometeam,MIN
 info,site,MIN02
 info,date,1967/08/09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,dimul901
@@ -8690,7 +8690,7 @@ info,hometeam,MIN
 info,site,MIN02
 info,date,1967/08/10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,odomj901
@@ -9302,7 +9302,7 @@ info,hometeam,MIN
 info,site,MIN02
 info,date,1967/08/28
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,chyln901
@@ -9432,7 +9432,7 @@ info,hometeam,MIN
 info,site,MIN02
 info,date,1967/08/29
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,drumc901
@@ -9577,7 +9577,7 @@ info,hometeam,MIN
 info,site,MIN02
 info,date,1967/08/30
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,sprim901
@@ -9718,7 +9718,7 @@ info,hometeam,MIN
 info,site,MIN02
 info,date,1967/08/31
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,honoj901
@@ -10357,7 +10357,7 @@ info,hometeam,MIN
 info,site,MIN02
 info,date,1967/09/04
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,honoj901
@@ -10486,7 +10486,7 @@ info,hometeam,MIN
 info,site,MIN02
 info,date,1967/09/04
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,chyln901
@@ -10630,7 +10630,7 @@ info,hometeam,MIN
 info,site,MIN02
 info,date,1967/09/05
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,drumc901
@@ -10797,7 +10797,7 @@ info,hometeam,MIN
 info,site,MIN02
 info,date,1967/09/06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,sprim901
@@ -11659,7 +11659,7 @@ info,hometeam,MIN
 info,site,MIN02
 info,date,1967/09/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dimul901
@@ -11841,7 +11841,7 @@ info,hometeam,MIN
 info,site,MIN02
 info,date,1967/09/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,neudj901
@@ -11978,7 +11978,7 @@ info,hometeam,MIN
 info,site,MIN02
 info,date,1967/09/27
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stevj901

--- a/event/regular/1967NYA.EVA
+++ b/event/regular/1967NYA.EVA
@@ -823,7 +823,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1967/04/28
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,salea901
@@ -972,7 +972,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1967/04/29
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,odomj901
@@ -1101,7 +1101,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1967/04/30
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,soarh901
@@ -1251,7 +1251,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1967/04/30
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,salea901
@@ -1394,7 +1394,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1967/05/12
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,dimul901
@@ -1549,7 +1549,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1967/05/13
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,ashfe901
@@ -3258,7 +3258,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1967/06/05
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,dimul901
@@ -3384,7 +3384,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1967/06/06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,ashfe901
@@ -3525,7 +3525,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1967/06/07
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,flahr901
@@ -3657,7 +3657,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1967/06/07
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,ricej901
@@ -3801,7 +3801,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1967/06/08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,dimul901
@@ -9739,7 +9739,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1967/08/31
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,ricej901
@@ -9877,7 +9877,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1967/09/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,ashfe901
@@ -10034,7 +10034,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1967/09/02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,flahr901
@@ -10155,7 +10155,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1967/09/03
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,salea901

--- a/event/regular/1967PIT.EVN
+++ b/event/regular/1967PIT.EVN
@@ -6028,7 +6028,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1967/07/07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,pryop901
@@ -6179,7 +6179,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1967/07/08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,engeb901
@@ -6323,7 +6323,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1967/07/09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,gormt101
@@ -7513,7 +7513,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1967/08/04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,willb901
@@ -7685,7 +7685,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1967/08/05
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,secof101
@@ -7814,7 +7814,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1967/08/06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,burkk101
@@ -7970,7 +7970,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1967/08/14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,kiblj901
@@ -8121,7 +8121,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1967/08/15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,craws901
@@ -8253,7 +8253,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1967/08/16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,pelec901
@@ -9371,7 +9371,7 @@ info,hometeam,PIT
 info,site,PIT06
 info,date,1967/08/22
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,pryop901

--- a/event/regular/1967SLN.EVN
+++ b/event/regular/1967SLN.EVN
@@ -1989,7 +1989,7 @@ info,hometeam,SLN
 info,site,STL09
 info,date,1967/06/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,donaa901

--- a/event/regular/1967WS2.EVA
+++ b/event/regular/1967WS2.EVA
@@ -5,7 +5,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/04/10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stevj901
@@ -149,7 +149,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/04/12
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,stewb902
@@ -298,7 +298,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/04/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,neudj901
@@ -453,7 +453,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/04/21
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,nappl901
@@ -586,7 +586,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/04/22
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,umonf901
@@ -716,7 +716,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/04/23
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,kinnb901
@@ -863,7 +863,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/04/24
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,valeb901
@@ -1037,7 +1037,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/04/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,sprim901
@@ -1182,7 +1182,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/04/28
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,dimul901
@@ -1328,7 +1328,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/04/29
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,ashfe901
@@ -1502,7 +1502,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/04/30
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,flahr901
@@ -1650,7 +1650,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/04/30
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,ricej901
@@ -1776,7 +1776,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/05/11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,kinnb901
@@ -1906,7 +1906,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/05/12
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,neudj901
@@ -2096,7 +2096,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/05/13
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,nappl901
@@ -2242,7 +2242,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/05/14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,umonf901
@@ -2337,7 +2337,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/05/16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,honoj901
@@ -2482,7 +2482,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/05/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,chyln901
@@ -2626,7 +2626,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/05/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,drumc901
@@ -2753,7 +2753,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/05/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,hallb901
@@ -2927,7 +2927,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/05/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,honoj901
@@ -3075,7 +3075,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/05/30
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stewb902
@@ -3208,7 +3208,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/05/30
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,valeb901
@@ -3383,7 +3383,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/05/31
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,sprim901
@@ -3529,7 +3529,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/06/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,stevj901
@@ -3662,7 +3662,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/06/12
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,ashfe901
@@ -3944,7 +3944,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/06/13
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,flahr901
@@ -4077,7 +4077,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/06/14
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,ricej901
@@ -4217,7 +4217,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/06/14
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,dimul901
@@ -4349,7 +4349,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/06/15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,ashfe901
@@ -4481,7 +4481,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/06/16
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,flahr901
@@ -4623,7 +4623,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/06/16
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,ricej901
@@ -4770,7 +4770,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/06/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dimul901
@@ -4912,7 +4912,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/06/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,ashfe901
@@ -5059,7 +5059,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/06/23
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,umonf901
@@ -5195,7 +5195,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/06/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,neudj901
@@ -5341,7 +5341,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/07/13
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,flahr901
@@ -5478,7 +5478,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/07/13
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,ashfe901
@@ -5603,7 +5603,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/07/14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,ricej901
@@ -5732,7 +5732,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/07/15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dimul901
@@ -5872,7 +5872,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/07/16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,ashfe901
@@ -6007,7 +6007,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/07/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,flahr901
@@ -6167,7 +6167,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/07/23
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dimul901
@@ -6337,7 +6337,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/07/25
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,odomj901
@@ -6471,7 +6471,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/07/25
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,soarh901
@@ -6641,7 +6641,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/07/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,salea901
@@ -6787,7 +6787,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/07/27
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,runge901
@@ -6939,7 +6939,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/07/28
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,odomj901
@@ -7077,7 +7077,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/07/29
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,soarh901
@@ -7251,7 +7251,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/07/30
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,salea901
@@ -7399,7 +7399,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/07/30
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,runge901
@@ -7568,7 +7568,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/08/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,odomj901
@@ -7726,7 +7726,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/08/02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,soarh901
@@ -7904,7 +7904,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/08/15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,stewb902
@@ -8043,7 +8043,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/08/16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,dimul901
@@ -8166,7 +8166,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/08/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,neudj901
@@ -8423,7 +8423,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/08/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,stevj901
@@ -8572,7 +8572,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/08/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stewb902
@@ -8722,7 +8722,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/08/25
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,ashfe901
@@ -8870,7 +8870,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/08/25
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,flahr901
@@ -9021,7 +9021,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/08/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,salea901
@@ -9172,7 +9172,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/08/27
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,ricej901
@@ -9322,7 +9322,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/08/28
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,ashfe901
@@ -9457,7 +9457,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/08/29
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,flahr901
@@ -9583,7 +9583,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/08/30
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,salea901
@@ -9730,7 +9730,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/09/04
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,soarh901
@@ -9867,7 +9867,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/09/04
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,runge901
@@ -10036,7 +10036,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/09/05
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,hallb901
@@ -10187,7 +10187,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/09/08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,runge901
@@ -10310,7 +10310,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/09/09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hallb901
@@ -10458,7 +10458,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/09/10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,odomj901
@@ -10594,7 +10594,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/09/11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,honoj901
@@ -10777,7 +10777,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/09/12
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,chyln901
@@ -10932,7 +10932,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/09/13
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,drumc901
@@ -11081,7 +11081,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/09/20
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,stevj901
@@ -11221,7 +11221,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/09/20
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,stewb902
@@ -11394,7 +11394,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/09/21
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,dimul901
@@ -11573,7 +11573,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/09/22
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,neudj901
@@ -11734,7 +11734,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/09/22
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,stevj901
@@ -11886,7 +11886,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1967/09/24
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stewb902

--- a/event/regular/1968BOS.EVA
+++ b/event/regular/1968BOS.EVA
@@ -7070,7 +7070,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1968/07/29
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,salea901
@@ -7387,7 +7387,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1968/07/30
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,valeb901

--- a/event/regular/1968CHA.EVA
+++ b/event/regular/1968CHA.EVA
@@ -6994,7 +6994,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1968/07/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stewb902

--- a/event/regular/1968DET.EVA
+++ b/event/regular/1968DET.EVA
@@ -6720,7 +6720,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1968/07/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,drumc901
@@ -6878,7 +6878,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1968/07/21
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,odomj901

--- a/event/regular/1968NYA.EVA
+++ b/event/regular/1968NYA.EVA
@@ -5807,7 +5807,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1968/07/06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,valeb901
@@ -5952,7 +5952,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1968/07/07
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,honoj901

--- a/event/regular/1969BOS.EVA
+++ b/event/regular/1969BOS.EVA
@@ -6,7 +6,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1969/04/14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,ricej901
@@ -156,7 +156,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1969/04/15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,goetr901
@@ -335,7 +335,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1969/04/16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,kunkb101
@@ -494,7 +494,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1969/04/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,nappl901
@@ -7709,7 +7709,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1969/07/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,sprim901

--- a/event/regular/1969DET.EVA
+++ b/event/regular/1969DET.EVA
@@ -5700,7 +5700,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1969/07/04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,frana901
@@ -5812,7 +5812,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1969/07/05
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,soarh901
@@ -5977,7 +5977,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1969/07/06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,anthm901

--- a/event/regular/1969NYA.EVA
+++ b/event/regular/1969NYA.EVA
@@ -1438,7 +1438,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1969/05/03
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,chyln901
@@ -1588,7 +1588,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1969/05/04
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,odonj901
@@ -5612,7 +5612,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1969/07/02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,denkd901

--- a/event/regular/1969WS2.EVA
+++ b/event/regular/1969WS2.EVA
@@ -469,7 +469,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1969/04/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,kinnb901
@@ -612,7 +612,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1969/04/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,ashfe901
@@ -771,7 +771,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1969/04/20
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,frana901
@@ -932,7 +932,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1969/04/20
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,soarh901

--- a/event/regular/1970BOS.EVA
+++ b/event/regular/1970BOS.EVA
@@ -4900,7 +4900,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1970/06/22
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,barnl901
@@ -5405,7 +5405,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1970/06/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,sprim901
@@ -6126,7 +6126,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1970/07/03
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,odomj901
@@ -6251,7 +6251,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1970/07/03
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,runge901
@@ -6436,7 +6436,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1970/07/04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,kunkb101
@@ -6570,7 +6570,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1970/07/05
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hallb901
@@ -6725,7 +6725,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1970/07/16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,malog901
@@ -6901,7 +6901,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1970/07/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,honoj901
@@ -7054,7 +7054,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1970/07/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,umonf901
@@ -7528,7 +7528,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1970/07/21
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,ashfe901
@@ -7687,7 +7687,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1970/07/22
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,soarh901
@@ -7840,7 +7840,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1970/07/22
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,dimul901
@@ -7990,7 +7990,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1970/07/23
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,neudj901
@@ -8149,7 +8149,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1970/08/08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,runge901
@@ -8310,7 +8310,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1970/08/09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,kunkb101
@@ -8463,7 +8463,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1970/08/10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hallb901
@@ -8636,7 +8636,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1970/08/12
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,dimul901
@@ -8773,7 +8773,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1970/08/12
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,neudj901
@@ -8912,7 +8912,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1970/08/13
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,ashfe901
@@ -9070,7 +9070,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1970/08/14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,soarh901
@@ -9222,7 +9222,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1970/08/15
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dimul901
@@ -9357,7 +9357,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1970/08/15
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,neudj901
@@ -9527,7 +9527,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1970/08/16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,ashfe901
@@ -9695,7 +9695,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1970/08/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,stewb902
@@ -9843,7 +9843,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1970/08/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,lucir901
@@ -9993,7 +9993,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1970/08/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,flahr901
@@ -10166,7 +10166,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1970/08/31
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,nappl901
@@ -10304,7 +10304,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1970/09/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,ricej901
@@ -10484,7 +10484,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1970/09/02
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,sprim901
@@ -10648,7 +10648,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1970/09/02
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,barnl901
@@ -10799,7 +10799,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1970/09/03
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,nappl901
@@ -11117,7 +11117,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1970/09/05
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,sprim901
@@ -11258,7 +11258,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1970/09/06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,barnl901
@@ -11460,7 +11460,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1970/09/19
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,chyln901
@@ -11619,7 +11619,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1970/09/19
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,goetr901
@@ -11773,7 +11773,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1970/09/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,denkd901
@@ -11900,7 +11900,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1970/09/21
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,frana901
@@ -12037,7 +12037,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1970/09/22
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,chyln901
@@ -12193,7 +12193,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1970/09/23
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,goetr901
@@ -12515,7 +12515,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1970/09/30
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,neudj901

--- a/event/regular/1970CAL.EVA
+++ b/event/regular/1970CAL.EVA
@@ -8346,7 +8346,7 @@ info,hometeam,CAL
 info,site,ANA01
 info,date,1970/07/31
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,barnl901
@@ -8465,7 +8465,7 @@ info,hometeam,CAL
 info,site,ANA01
 info,date,1970/08/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,nappl901
@@ -8597,7 +8597,7 @@ info,hometeam,CAL
 info,site,ANA01
 info,date,1970/08/02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,ricej901

--- a/event/regular/1970CHA.EVA
+++ b/event/regular/1970CHA.EVA
@@ -9987,7 +9987,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1970/08/28
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,odonj901
@@ -10128,7 +10128,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1970/08/29
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,malog901
@@ -10304,7 +10304,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1970/08/30
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,honoj901
@@ -10492,7 +10492,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1970/08/30
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,umonf901

--- a/event/regular/1970CLE.EVA
+++ b/event/regular/1970CLE.EVA
@@ -5816,7 +5816,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1970/07/10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,dimul901
@@ -5965,7 +5965,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1970/07/11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,neudj901
@@ -6103,7 +6103,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1970/07/12
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,ashfe901
@@ -6252,7 +6252,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1970/07/12
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,soarh901
@@ -10522,7 +10522,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1970/09/07
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,nappl901
@@ -10691,7 +10691,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1970/09/07
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,ricej901
@@ -10838,7 +10838,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1970/09/08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,sprim901

--- a/event/regular/1970DET.EVA
+++ b/event/regular/1970DET.EVA
@@ -5647,7 +5647,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1970/07/06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,ricej901
@@ -5815,7 +5815,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1970/07/07
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,sprim901
@@ -5975,7 +5975,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1970/07/07
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,barnl901
@@ -6131,7 +6131,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1970/07/08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,nappl901
@@ -6278,7 +6278,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1970/07/09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,ricej901
@@ -10917,7 +10917,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1970/09/09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,stevj901
@@ -11059,7 +11059,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1970/09/10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,neudj901

--- a/event/regular/1970KCA.EVA
+++ b/event/regular/1970KCA.EVA
@@ -4714,7 +4714,7 @@ info,hometeam,KCA
 info,site,KAN05
 info,date,1970/06/15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,odonj901
@@ -4875,7 +4875,7 @@ info,hometeam,KCA
 info,site,KAN05
 info,date,1970/06/16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,malog901
@@ -5032,7 +5032,7 @@ info,hometeam,KCA
 info,site,KAN05
 info,date,1970/06/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,honoj901
@@ -9130,7 +9130,7 @@ info,hometeam,KCA
 info,site,KAN05
 info,date,1970/08/21
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,umonf901
@@ -9289,7 +9289,7 @@ info,hometeam,KCA
 info,site,KAN05
 info,date,1970/08/22
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,odonj901
@@ -9435,7 +9435,7 @@ info,hometeam,KCA
 info,site,KAN05
 info,date,1970/08/23
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,malog901

--- a/event/regular/1970MIL.EVA
+++ b/event/regular/1970MIL.EVA
@@ -4015,7 +4015,7 @@ info,hometeam,MIL
 info,site,MIL05
 info,date,1970/06/06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,kunkb101
@@ -4175,7 +4175,7 @@ info,hometeam,MIL
 info,site,MIL05
 info,date,1970/06/07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hallb901
@@ -7694,7 +7694,7 @@ info,hometeam,MIL
 info,site,MIL05
 info,date,1970/07/24
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,ashfe901
@@ -7827,7 +7827,7 @@ info,hometeam,MIL
 info,site,MIL05
 info,date,1970/07/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,soarh901
@@ -7959,7 +7959,7 @@ info,hometeam,MIL
 info,site,MIL05
 info,date,1970/07/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dimul901

--- a/event/regular/1970MIN.EVA
+++ b/event/regular/1970MIN.EVA
@@ -3490,7 +3490,7 @@ info,hometeam,MIN
 info,site,MIN02
 info,date,1970/06/12
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,neudj901
@@ -3658,7 +3658,7 @@ info,hometeam,MIN
 info,site,MIN02
 info,date,1970/06/13
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,ashfe901
@@ -3808,7 +3808,7 @@ info,hometeam,MIN
 info,site,MIN02
 info,date,1970/06/14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,soarh901
@@ -9405,7 +9405,7 @@ info,hometeam,MIN
 info,site,MIN02
 info,date,1970/08/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,frana901
@@ -9560,7 +9560,7 @@ info,hometeam,MIN
 info,site,MIN02
 info,date,1970/08/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,chyln901
@@ -9697,7 +9697,7 @@ info,hometeam,MIN
 info,site,MIN02
 info,date,1970/08/27
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,goetr901

--- a/event/regular/1970NYA.EVA
+++ b/event/regular/1970NYA.EVA
@@ -9710,7 +9710,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1970/09/02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,honoj901

--- a/event/regular/1970NYN.EVN
+++ b/event/regular/1970NYN.EVN
@@ -494,7 +494,7 @@ info,hometeam,NYN
 info,site,NYC17
 info,date,1970/04/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,steld901

--- a/event/regular/1970OAK.EVA
+++ b/event/regular/1970OAK.EVA
@@ -9233,7 +9233,7 @@ info,hometeam,OAK
 info,site,OAK01
 info,date,1970/08/15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,frana901
@@ -9382,7 +9382,7 @@ info,hometeam,OAK
 info,site,OAK01
 info,date,1970/08/16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,chyln901

--- a/event/regular/1970WS2.EVA
+++ b/event/regular/1970WS2.EVA
@@ -6010,7 +6010,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1970/06/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,frana901
@@ -6333,7 +6333,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1970/06/28
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,goetr901
@@ -8132,7 +8132,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1970/08/06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,lucir901
@@ -8268,7 +8268,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1970/08/07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,flahr901
@@ -12201,7 +12201,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1970/09/24
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,stewb902
@@ -12364,7 +12364,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1970/09/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,lucir901
@@ -12503,7 +12503,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1970/09/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,flahr901
@@ -12682,7 +12682,7 @@ info,hometeam,WS2
 info,site,WAS10
 info,date,1970/09/27
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,anthm901

--- a/event/regular/1971NYA.EVA
+++ b/event/regular/1971NYA.EVA
@@ -7973,7 +7973,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1971/08/07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,sprim901
@@ -8114,7 +8114,7 @@ info,hometeam,NYA
 info,site,NYC16
 info,date,1971/08/08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,honoj901

--- a/event/regular/1971OAK.EVA
+++ b/event/regular/1971OAK.EVA
@@ -6823,7 +6823,7 @@ info,hometeam,OAK
 info,site,OAK01
 info,date,1971/07/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,flahr901
@@ -6990,7 +6990,7 @@ info,hometeam,OAK
 info,site,OAK01
 info,date,1971/07/19
 info,number,0
-info,starttime,0:00AM
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,ricej901

--- a/event/regular/1972BOS.EVA
+++ b/event/regular/1972BOS.EVA
@@ -7271,7 +7271,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1972/08/03
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,flahr901

--- a/event/regular/1972CAL.EVA
+++ b/event/regular/1972CAL.EVA
@@ -6637,7 +6637,7 @@ info,hometeam,CAL
 info,site,ANA01
 info,date,1972/07/12
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,goetr901

--- a/event/regular/1972KCA.EVA
+++ b/event/regular/1972KCA.EVA
@@ -8778,7 +8778,7 @@ info,hometeam,KCA
 info,site,KAN05
 info,date,1972/08/15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,malog901
@@ -8960,7 +8960,7 @@ info,hometeam,KCA
 info,site,KAN05
 info,date,1972/08/16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,nappl901

--- a/event/regular/1972MIL.EVA
+++ b/event/regular/1972MIL.EVA
@@ -11208,7 +11208,7 @@ info,hometeam,MIL
 info,site,MIL05
 info,date,1972/09/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,chyln901

--- a/event/regular/1973DET.EVA
+++ b/event/regular/1973DET.EVA
@@ -5271,7 +5271,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1973/07/01
 info,number,1
-info,starttime,0:00AM
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,true
 info,umphome,evanj901

--- a/event/regular/1973MIN.EVA
+++ b/event/regular/1973MIN.EVA
@@ -455,7 +455,7 @@ info,hometeam,MIN
 info,site,MIN02
 info,date,1973/04/18
 info,number,0
-info,starttime,0:00AM
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,true
 info,umphome,dimul901

--- a/event/regular/1973MON.EVN
+++ b/event/regular/1973MON.EVN
@@ -6215,7 +6215,7 @@ info,hometeam,MON
 info,site,MON01
 info,date,1973/07/08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,craws901
@@ -8422,7 +8422,7 @@ info,hometeam,MON
 info,site,MON01
 info,date,1973/08/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,froeb901

--- a/event/regular/1974ATL.EVN
+++ b/event/regular/1974ATL.EVN
@@ -2537,7 +2537,7 @@ info,hometeam,ATL
 info,site,ATL01
 info,date,1974/05/11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,kiblj901
@@ -2704,7 +2704,7 @@ info,hometeam,ATL
 info,site,ATL01
 info,date,1974/05/12
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,olsea901
@@ -3916,7 +3916,7 @@ info,hometeam,ATL
 info,site,ATL01
 info,date,1974/06/08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,harvd901
@@ -4073,7 +4073,7 @@ info,hometeam,ATL
 info,site,ATL01
 info,date,1974/06/09
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,wendh901
@@ -4218,7 +4218,7 @@ info,hometeam,ATL
 info,site,ATL01
 info,date,1974/06/09
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,colon901
@@ -5763,7 +5763,7 @@ info,hometeam,ATL
 info,site,ATL01
 info,date,1974/06/30
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,sudoe901
@@ -12507,7 +12507,7 @@ info,hometeam,ATL
 info,site,ATL01
 info,date,1974/10/02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,harvd901

--- a/event/regular/1974CHA.EVA
+++ b/event/regular/1974CHA.EVA
@@ -9203,7 +9203,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1974/08/24
 info,number,0
-info,starttime,0:00AM
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,true
 info,umphome,chyln901
@@ -10821,7 +10821,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1974/09/13
 info,number,1
-info,starttime,0:00AM
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,true
 info,umphome,kunkb101

--- a/event/regular/1974CHN.EVN
+++ b/event/regular/1974CHN.EVN
@@ -466,7 +466,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1974/04/13
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mcshj901
@@ -1486,7 +1486,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1974/05/04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,craws901
@@ -3202,7 +3202,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1974/05/29
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,pryop901
@@ -3362,7 +3362,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1974/05/30
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,engeb901
@@ -4150,7 +4150,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1974/06/15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,olsea901
@@ -6375,7 +6375,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1974/07/06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,pullf901

--- a/event/regular/1974CIN.EVN
+++ b/event/regular/1974CIN.EVN
@@ -207,7 +207,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1974/04/06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,froeb901
@@ -378,7 +378,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1974/04/07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mcshj901
@@ -1021,7 +1021,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1974/04/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,harvd901
@@ -1184,7 +1184,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1974/04/21
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,wendh901
@@ -2331,7 +2331,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1974/05/12
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,weyel901
@@ -2890,7 +2890,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1974/05/15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,gormt101
@@ -4713,7 +4713,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1974/06/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,froeb901
@@ -5009,7 +5009,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1974/06/22
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,engeb901
@@ -5135,7 +5135,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1974/06/23
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dalej901
@@ -5887,7 +5887,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1974/07/04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,wendh901
@@ -6212,7 +6212,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1974/07/06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,steld901
@@ -6348,7 +6348,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1974/07/07
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,tatat901
@@ -9450,7 +9450,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1974/08/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mcshj901
@@ -10412,7 +10412,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1974/09/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,pryop901
@@ -10710,7 +10710,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1974/09/07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,froeb901
@@ -10881,7 +10881,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1974/09/08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,rungp901
@@ -11453,7 +11453,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1974/09/12
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,willa901
@@ -11630,7 +11630,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1974/09/12
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,wendh901
@@ -12403,7 +12403,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1974/09/28
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,rungp901
@@ -12588,7 +12588,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1974/09/29
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,varge901

--- a/event/regular/1974HOU.EVN
+++ b/event/regular/1974HOU.EVN
@@ -484,7 +484,7 @@ info,hometeam,HOU
 info,site,HOU02
 info,date,1974/04/15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,willb901
@@ -622,7 +622,7 @@ info,hometeam,HOU
 info,site,HOU02
 info,date,1974/04/16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,steld901
@@ -762,7 +762,7 @@ info,hometeam,HOU
 info,site,HOU02
 info,date,1974/04/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,tatat901
@@ -919,7 +919,7 @@ info,hometeam,HOU
 info,site,HOU02
 info,date,1974/04/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,gormt101
@@ -1083,7 +1083,7 @@ info,hometeam,HOU
 info,site,HOU02
 info,date,1974/04/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,willb901
@@ -1236,7 +1236,7 @@ info,hometeam,HOU
 info,site,HOU02
 info,date,1974/04/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,steld901
@@ -1396,7 +1396,7 @@ info,hometeam,HOU
 info,site,HOU02
 info,date,1974/04/21
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,tatat901
@@ -1566,7 +1566,7 @@ info,hometeam,HOU
 info,site,HOU02
 info,date,1974/04/22
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,gormt101
@@ -1900,7 +1900,7 @@ info,hometeam,HOU
 info,site,HOU02
 info,date,1974/04/30
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,colon901
@@ -3496,7 +3496,7 @@ info,hometeam,HOU
 info,site,HOU02
 info,date,1974/05/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,tatat901
@@ -4137,7 +4137,7 @@ info,hometeam,HOU
 info,site,HOU02
 info,date,1974/06/04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,dalej901
@@ -4270,7 +4270,7 @@ info,hometeam,HOU
 info,site,HOU02
 info,date,1974/06/05
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,pelec901
@@ -4436,7 +4436,7 @@ info,hometeam,HOU
 info,site,HOU02
 info,date,1974/06/06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,pryop901
@@ -5554,7 +5554,7 @@ info,hometeam,HOU
 info,site,HOU02
 info,date,1974/06/21
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,rennd901
@@ -7360,7 +7360,7 @@ info,hometeam,HOU
 info,site,HOU02
 info,date,1974/07/12
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,gormt101

--- a/event/regular/1974LAN.EVN
+++ b/event/regular/1974LAN.EVN
@@ -10629,7 +10629,7 @@ info,hometeam,LAN
 info,site,LOS03
 info,date,1974/09/15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,sudoe901

--- a/event/regular/1974MIN.EVA
+++ b/event/regular/1974MIN.EVA
@@ -6544,7 +6544,7 @@ info,hometeam,MIN
 info,site,MIN02
 info,date,1974/07/09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,true
 info,umphome,goetr901

--- a/event/regular/1974MON.EVN
+++ b/event/regular/1974MON.EVN
@@ -436,7 +436,7 @@ info,hometeam,MON
 info,site,MON01
 info,date,1974/05/04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,pullf901
@@ -579,7 +579,7 @@ info,hometeam,MON
 info,site,MON01
 info,date,1974/05/05
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,sudoe901
@@ -712,7 +712,7 @@ info,hometeam,MON
 info,site,MON01
 info,date,1974/05/05
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,davis901
@@ -2134,7 +2134,7 @@ info,hometeam,MON
 info,site,MON01
 info,date,1974/05/30
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,pullf901
@@ -2520,7 +2520,7 @@ info,hometeam,MON
 info,site,MON01
 info,date,1974/06/02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,willa901
@@ -3498,7 +3498,7 @@ info,hometeam,MON
 info,site,MON01
 info,date,1974/06/16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,pryop901

--- a/event/regular/1974NYN.EVN
+++ b/event/regular/1974NYN.EVN
@@ -3597,7 +3597,7 @@ info,hometeam,NYN
 info,site,NYC17
 info,date,1974/06/06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,colon901
@@ -8044,7 +8044,7 @@ info,hometeam,NYN
 info,site,NYC17
 info,date,1974/08/10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,pullf901
@@ -8232,7 +8232,7 @@ info,hometeam,NYN
 info,site,NYC17
 info,date,1974/08/11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dalej901

--- a/event/regular/1974PIT.EVN
+++ b/event/regular/1974PIT.EVN
@@ -757,7 +757,7 @@ info,hometeam,PIT
 info,site,PIT07
 info,date,1974/04/14
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,olsea901
@@ -4321,7 +4321,7 @@ info,hometeam,PIT
 info,site,PIT07
 info,date,1974/06/16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,harvd901
@@ -5490,7 +5490,7 @@ info,hometeam,PIT
 info,site,PIT07
 info,date,1974/07/03
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,pryop901
@@ -5920,7 +5920,7 @@ info,hometeam,PIT
 info,site,PIT07
 info,date,1974/07/08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,willb901
@@ -6067,7 +6067,7 @@ info,hometeam,PIT
 info,site,PIT07
 info,date,1974/07/09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,steld901
@@ -6688,7 +6688,7 @@ info,hometeam,PIT
 info,site,PIT07
 info,date,1974/07/13
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,davis901

--- a/event/regular/1974SDN.EVN
+++ b/event/regular/1974SDN.EVN
@@ -189,7 +189,7 @@ info,hometeam,SDN
 info,site,SAN01
 info,date,1974/04/10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,harvd901

--- a/event/regular/1974SFN.EVN
+++ b/event/regular/1974SFN.EVN
@@ -450,7 +450,7 @@ info,hometeam,SFN
 info,site,SFO02
 info,date,1974/04/08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dalej901
@@ -756,7 +756,7 @@ info,hometeam,SFN
 info,site,SFO02
 info,date,1974/04/10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,pryop901
@@ -895,7 +895,7 @@ info,hometeam,SFN
 info,site,SFO02
 info,date,1974/04/23
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,pullf901
@@ -1055,7 +1055,7 @@ info,hometeam,SFN
 info,site,SFO02
 info,date,1974/04/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,sudoe901
@@ -3083,7 +3083,7 @@ info,hometeam,SFN
 info,site,SFO02
 info,date,1974/05/22
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,steld901
@@ -5163,7 +5163,7 @@ info,hometeam,SFN
 info,site,SFO02
 info,date,1974/06/13
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,rungp901
@@ -12041,7 +12041,7 @@ info,hometeam,SFN
 info,site,SFO02
 info,date,1974/09/22
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,pryop901

--- a/event/regular/1974SLN.EVN
+++ b/event/regular/1974SLN.EVN
@@ -324,7 +324,7 @@ info,hometeam,SLN
 info,site,STL09
 info,date,1974/04/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,dalej901
@@ -484,7 +484,7 @@ info,hometeam,SLN
 info,site,STL09
 info,date,1974/04/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,pelec901

--- a/event/regular/1975ATL.EVN
+++ b/event/regular/1975ATL.EVN
@@ -12059,7 +12059,7 @@ info,hometeam,ATL
 info,site,ATL01
 info,date,1975/09/21
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,craws901

--- a/event/regular/1975BAL.EVA
+++ b/event/regular/1975BAL.EVA
@@ -5369,7 +5369,7 @@ info,hometeam,BAL
 info,site,BAL11
 info,date,1975/06/26
 info,number,0
-info,starttime,0:00AM
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,true
 info,umphome,hallb901

--- a/event/regular/1975CHN.EVN
+++ b/event/regular/1975CHN.EVN
@@ -4110,7 +4110,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1975/06/13
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,willa901
@@ -10255,7 +10255,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1975/08/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,colon901
@@ -10422,7 +10422,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1975/08/27
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mcshj901

--- a/event/regular/1975CIN.EVN
+++ b/event/regular/1975CIN.EVN
@@ -6,7 +6,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1975/04/07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,pelec901
@@ -670,7 +670,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1975/04/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,davis901
@@ -846,7 +846,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1975/04/20
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,pullf901
@@ -1361,7 +1361,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1975/04/22
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,pryop901
@@ -1817,7 +1817,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1975/05/04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,engeb901
@@ -3064,7 +3064,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1975/05/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,varge901
@@ -3219,7 +3219,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1975/05/26
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,olsea901
@@ -3382,7 +3382,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1975/05/26
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,tatat901
@@ -5193,7 +5193,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1975/06/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,davis901
@@ -5691,7 +5691,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1975/06/29
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,tatat901
@@ -5827,7 +5827,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1975/06/29
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,sudoe901
@@ -7465,7 +7465,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1975/07/13
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,pryop901
@@ -7946,7 +7946,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1975/07/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,rennd901
@@ -8089,7 +8089,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1975/07/27
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,harvd901
@@ -9243,7 +9243,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1975/08/10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,gormt101
@@ -11827,7 +11827,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1975/09/07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,tatat901
@@ -12501,7 +12501,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1975/09/27
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,weyel901
@@ -12707,7 +12707,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1975/09/28
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,davis901

--- a/event/regular/1975HOU.EVN
+++ b/event/regular/1975HOU.EVN
@@ -2060,7 +2060,7 @@ info,hometeam,HOU
 info,site,HOU02
 info,date,1975/04/27
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,varge901
@@ -5021,7 +5021,7 @@ info,hometeam,HOU
 info,site,HOU02
 info,date,1975/06/22
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,pelec901

--- a/event/regular/1975LAN.EVN
+++ b/event/regular/1975LAN.EVN
@@ -419,7 +419,7 @@ info,hometeam,LAN
 info,site,LOS03
 info,date,1975/04/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,gormt101
@@ -8113,7 +8113,7 @@ info,hometeam,LAN
 info,site,LOS03
 info,date,1975/08/03
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,rennd901

--- a/event/regular/1975MON.EVN
+++ b/event/regular/1975MON.EVN
@@ -2663,7 +2663,7 @@ info,hometeam,MON
 info,site,MON01
 info,date,1975/05/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mcshj901
@@ -2838,7 +2838,7 @@ info,hometeam,MON
 info,site,MON01
 info,date,1975/05/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,pelec901
@@ -6876,7 +6876,7 @@ info,hometeam,MON
 info,site,MON01
 info,date,1975/07/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,steld901

--- a/event/regular/1975NYN.EVN
+++ b/event/regular/1975NYN.EVN
@@ -1884,7 +1884,7 @@ info,hometeam,NYN
 info,site,NYC17
 info,date,1975/05/10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,craws901
@@ -2045,7 +2045,7 @@ info,hometeam,NYN
 info,site,NYC17
 info,date,1975/05/11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,kiblj901

--- a/event/regular/1975PHI.EVN
+++ b/event/regular/1975PHI.EVN
@@ -7489,7 +7489,7 @@ info,hometeam,PHI
 info,site,PHI12
 info,date,1975/07/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,harvd901

--- a/event/regular/1975SDN.EVN
+++ b/event/regular/1975SDN.EVN
@@ -451,7 +451,7 @@ info,hometeam,SDN
 info,site,SAN01
 info,date,1975/04/13
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,engeb901

--- a/event/regular/1975SFN.EVN
+++ b/event/regular/1975SFN.EVN
@@ -1684,7 +1684,7 @@ info,hometeam,SFN
 info,site,SFO02
 info,date,1975/04/30
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,pryop901
@@ -8652,7 +8652,7 @@ info,hometeam,SFN
 info,site,SFO02
 info,date,1975/08/06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dalej901
@@ -11129,7 +11129,7 @@ info,hometeam,SFN
 info,site,SFO02
 info,date,1975/09/13
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,willb901
@@ -11281,7 +11281,7 @@ info,hometeam,SFN
 info,site,SFO02
 info,date,1975/09/14
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,olsea901

--- a/event/regular/1976ATL.EVN
+++ b/event/regular/1976ATL.EVN
@@ -10438,7 +10438,7 @@ info,hometeam,ATL
 info,site,ATL01
 info,date,1976/09/05
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,rennd901

--- a/event/regular/1976CHN.EVN
+++ b/event/regular/1976CHN.EVN
@@ -1955,7 +1955,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1976/05/08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mcshj901
@@ -2132,7 +2132,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1976/05/09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,willa901
@@ -8045,7 +8045,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1976/08/04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,rennd901
@@ -8208,7 +8208,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1976/08/10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,harvd901
@@ -8350,7 +8350,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1976/08/11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,pullf901
@@ -8563,7 +8563,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1976/08/12
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,kiblj901

--- a/event/regular/1976CIN.EVN
+++ b/event/regular/1976CIN.EVN
@@ -6,7 +6,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1976/04/08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,weyel901
@@ -172,7 +172,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1976/04/10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,colon901
@@ -349,7 +349,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1976/04/11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,rungp901
@@ -698,7 +698,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1976/04/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,pullf901
@@ -857,7 +857,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1976/04/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,tatat901
@@ -1485,7 +1485,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1976/05/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,pryop901
@@ -1632,7 +1632,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1976/05/02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mcshj901
@@ -2458,7 +2458,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1976/05/16
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,wendh901
@@ -2924,7 +2924,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1976/05/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,kiblj901
@@ -3220,7 +3220,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1976/05/29
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,olsea901
@@ -3370,7 +3370,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1976/05/30
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,rennd901
@@ -3881,7 +3881,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1976/06/12
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,willb901
@@ -4047,7 +4047,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1976/06/13
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,wendh901
@@ -5969,7 +5969,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1976/07/04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,monte901
@@ -6920,7 +6920,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1976/07/16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,engeb901
@@ -9649,7 +9649,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1976/08/22
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,froeb901
@@ -10467,7 +10467,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1976/08/28
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,olsea901
@@ -10654,7 +10654,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1976/08/29
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,davis901
@@ -11955,7 +11955,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1976/09/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,tatat901
@@ -12535,7 +12535,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1976/10/02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,davis901
@@ -12667,7 +12667,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1976/10/03
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,weyel901

--- a/event/regular/1976HOU.EVN
+++ b/event/regular/1976HOU.EVN
@@ -5677,7 +5677,7 @@ info,hometeam,HOU
 info,site,HOU02
 info,date,1976/06/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,davis901
@@ -5853,7 +5853,7 @@ info,hometeam,HOU
 info,site,HOU02
 info,date,1976/06/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,rennd901
@@ -5989,7 +5989,7 @@ info,hometeam,HOU
 info,site,HOU02
 info,date,1976/06/27
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,varge901
@@ -8729,7 +8729,7 @@ info,hometeam,HOU
 info,site,HOU02
 info,date,1976/08/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,weyel901

--- a/event/regular/1976LAN.EVN
+++ b/event/regular/1976LAN.EVN
@@ -11071,7 +11071,7 @@ info,hometeam,LAN
 info,site,LOS03
 info,date,1976/09/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,harvd901
@@ -11230,7 +11230,7 @@ info,hometeam,LAN
 info,site,LOS03
 info,date,1976/09/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,harvd901

--- a/event/regular/1976MON.EVN
+++ b/event/regular/1976MON.EVN
@@ -311,7 +311,7 @@ info,hometeam,MON
 info,site,MON01
 info,date,1976/04/23
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,sudoe901
@@ -457,7 +457,7 @@ info,hometeam,MON
 info,site,MON01
 info,date,1976/04/24
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,engeb901
@@ -621,7 +621,7 @@ info,hometeam,MON
 info,site,MON01
 info,date,1976/04/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,froeb901
@@ -3364,7 +3364,7 @@ info,hometeam,MON
 info,site,MON01
 info,date,1976/06/06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,engeb901

--- a/event/regular/1976NYN.EVN
+++ b/event/regular/1976NYN.EVN
@@ -1779,7 +1779,7 @@ info,hometeam,NYN
 info,site,NYC17
 info,date,1976/05/06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,monte901
@@ -7101,7 +7101,7 @@ info,hometeam,NYN
 info,site,NYC17
 info,date,1976/08/01
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,sudoe901
@@ -8562,7 +8562,7 @@ info,hometeam,NYN
 info,site,NYC17
 info,date,1976/08/14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,willb901
@@ -8710,7 +8710,7 @@ info,hometeam,NYN
 info,site,NYC17
 info,date,1976/08/15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,wendh901

--- a/event/regular/1976SFN.EVN
+++ b/event/regular/1976SFN.EVN
@@ -2530,7 +2530,7 @@ info,hometeam,SFN
 info,site,SFO02
 info,date,1976/05/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,pullf901
@@ -4591,7 +4591,7 @@ info,hometeam,SFN
 info,site,SFO02
 info,date,1976/06/10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,weyel901
@@ -4877,7 +4877,7 @@ info,hometeam,SFN
 info,site,SFO02
 info,date,1976/06/12
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,crawj901
@@ -8151,7 +8151,7 @@ info,hometeam,SFN
 info,site,SFO02
 info,date,1976/08/01
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,tatat901
@@ -8764,7 +8764,7 @@ info,hometeam,SFN
 info,site,SFO02
 info,date,1976/08/04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,tatat901
@@ -11311,7 +11311,7 @@ info,hometeam,SFN
 info,site,SFO02
 info,date,1976/09/11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,weyel901
@@ -11500,7 +11500,7 @@ info,hometeam,SFN
 info,site,SFO02
 info,date,1976/09/12
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,rungp901

--- a/event/regular/1978CLE.EVA
+++ b/event/regular/1978CLE.EVA
@@ -2300,7 +2300,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1978/05/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,true
 info,umphome,barnl901
@@ -2442,7 +2442,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1978/05/21
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,true
 info,umphome,evanj901

--- a/event/regular/1978MIN.EVA
+++ b/event/regular/1978MIN.EVA
@@ -2016,7 +2016,7 @@ info,hometeam,MIN
 info,site,MIN02
 info,date,1978/05/15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,true
 info,umphome,chyln901

--- a/event/regular/1980CHA.EVA
+++ b/event/regular/1980CHA.EVA
@@ -4118,7 +4118,7 @@ info,hometeam,CHA
 info,site,CHI10
 info,date,1980/06/06
 info,number,0
-info,starttime,0:00AM
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,true
 info,umphome,reilm901

--- a/event/regular/1980CLE.EVA
+++ b/event/regular/1980CLE.EVA
@@ -6,7 +6,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1980/04/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,true
 info,umphome,hendt901
@@ -150,7 +150,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1980/04/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,true
 info,umphome,barnl901
@@ -300,7 +300,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1980/04/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,true
 info,umphome,kunkb101
@@ -469,7 +469,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1980/04/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,true
 info,umphome,coont901
@@ -648,7 +648,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1980/04/27
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,true
 info,umphome,kaisk901

--- a/event/regular/1980DET.EVA
+++ b/event/regular/1980DET.EVA
@@ -3209,7 +3209,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1980/06/10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,true
 info,umphome,voltv901
@@ -3349,7 +3349,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1980/06/11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,true
 info,umphome,goetr901
@@ -3523,7 +3523,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1980/06/12
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,true
 info,umphome,malog901

--- a/event/regular/1980MIN.EVA
+++ b/event/regular/1980MIN.EVA
@@ -6,7 +6,7 @@ info,hometeam,MIN
 info,site,MIN02
 info,date,1980/04/22
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,true
 info,umphome,clara901
@@ -145,7 +145,7 @@ info,hometeam,MIN
 info,site,MIN02
 info,date,1980/04/23
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,true
 info,umphome,pales901
@@ -823,7 +823,7 @@ info,hometeam,MIN
 info,site,MIN02
 info,date,1980/04/28
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,true
 info,umphome,sprim901
@@ -986,7 +986,7 @@ info,hometeam,MIN
 info,site,MIN02
 info,date,1980/04/29
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,true
 info,umphome,brinj901
@@ -1143,7 +1143,7 @@ info,hometeam,MIN
 info,site,MIN02
 info,date,1980/04/30
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,true
 info,umphome,bremn901

--- a/event/regular/1980SEA.EVA
+++ b/event/regular/1980SEA.EVA
@@ -529,7 +529,7 @@ info,hometeam,SEA
 info,site,SEA02
 info,date,1980/04/13
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,true
 info,umphome,hendt901

--- a/event/regular/1981KCA.EVA
+++ b/event/regular/1981KCA.EVA
@@ -3371,7 +3371,7 @@ info,hometeam,KCA
 info,site,KAN06
 info,date,1981/06/08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,true
 info,umphome,hendt901

--- a/event/regular/1981TEX.EVA
+++ b/event/regular/1981TEX.EVA
@@ -3890,7 +3890,7 @@ info,hometeam,TEX
 info,site,ARL01
 info,date,1981/06/06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,true
 info,umphome,johnm901
@@ -4313,7 +4313,7 @@ info,hometeam,TEX
 info,site,ARL01
 info,date,1981/06/09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,true
 info,umphome,johnm901

--- a/event/regular/1982BOS.EVA
+++ b/event/regular/1982BOS.EVA
@@ -1821,7 +1821,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1982/05/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,true
 info,umphome,barnl901
@@ -2021,7 +2021,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1982/05/02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,true
 info,umphome,dimul901
@@ -4820,7 +4820,7 @@ info,hometeam,BOS
 info,site,BOS07
 info,date,1982/06/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,true
 info,umphome,denkd901

--- a/event/regular/1982CAL.EVA
+++ b/event/regular/1982CAL.EVA
@@ -6101,7 +6101,7 @@ info,hometeam,CAL
 info,site,ANA01
 info,date,1982/06/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,true
 info,umphome,kunkb101

--- a/event/regular/1982CLE.EVA
+++ b/event/regular/1982CLE.EVA
@@ -981,7 +981,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1982/04/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,true
 info,umphome,garcr901
@@ -1179,7 +1179,7 @@ info,hometeam,CLE
 info,site,CLE07
 info,date,1982/04/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,true
 info,umphome,denkd901

--- a/event/regular/1982DET.EVA
+++ b/event/regular/1982DET.EVA
@@ -593,7 +593,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1982/04/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,true
 info,umphome,sprim901
@@ -6692,7 +6692,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1982/07/24
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,true
 info,umphome,hallb901
@@ -6836,7 +6836,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1982/07/25
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,true
 info,umphome,neudj901
@@ -6981,7 +6981,7 @@ info,hometeam,DET
 info,site,DET04
 info,date,1982/07/25
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,true
 info,umphome,morrd901

--- a/event/regular/1982KCA.EVA
+++ b/event/regular/1982KCA.EVA
@@ -132,7 +132,7 @@ info,hometeam,KCA
 info,site,KAN06
 info,date,1982/04/10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,true
 info,umphome,bremn901
@@ -5545,7 +5545,7 @@ info,hometeam,KCA
 info,site,KAN06
 info,date,1982/07/02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,true
 info,umphome,voltv901
@@ -6319,7 +6319,7 @@ info,hometeam,KCA
 info,site,KAN06
 info,date,1982/07/06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,true
 info,umphome,cousd901

--- a/event/regular/1982MIL.EVA
+++ b/event/regular/1982MIL.EVA
@@ -6,7 +6,7 @@ info,hometeam,MIL
 info,site,MIL05
 info,date,1982/04/16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,true
 info,umphome,mccol901
@@ -153,7 +153,7 @@ info,hometeam,MIL
 info,site,MIL05
 info,date,1982/04/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,true
 info,umphome,brinj901
@@ -308,7 +308,7 @@ info,hometeam,MIL
 info,site,MIL05
 info,date,1982/04/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,true
 info,umphome,cousd901
@@ -5442,7 +5442,7 @@ info,hometeam,MIL
 info,site,MIL05
 info,date,1982/07/09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,true
 info,umphome,cobld901
@@ -7645,7 +7645,7 @@ info,hometeam,MIL
 info,site,MIL05
 info,date,1982/08/11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,true
 info,umphome,merrd901

--- a/event/regular/1982MIN.EVA
+++ b/event/regular/1982MIN.EVA
@@ -4959,7 +4959,7 @@ info,hometeam,MIN
 info,site,MIN03
 info,date,1982/06/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,true
 info,umphome,barnl901
@@ -5095,7 +5095,7 @@ info,hometeam,MIN
 info,site,MIN03
 info,date,1982/06/28
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,true
 info,umphome,reilm901
@@ -5430,7 +5430,7 @@ info,hometeam,MIN
 info,site,MIN03
 info,date,1982/06/30
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,true
 info,umphome,roe-r901
@@ -10681,7 +10681,7 @@ info,hometeam,MIN
 info,site,MIN03
 info,date,1982/09/16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,true
 info,umphome,garcr901
@@ -10827,7 +10827,7 @@ info,hometeam,MIN
 info,site,MIN03
 info,date,1982/09/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,true
 info,umphome,voltv901
@@ -10969,7 +10969,7 @@ info,hometeam,MIN
 info,site,MIN03
 info,date,1982/09/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,true
 info,umphome,shulj901
@@ -11119,7 +11119,7 @@ info,hometeam,MIN
 info,site,MIN03
 info,date,1982/09/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,true
 info,umphome,kunkb101

--- a/event/regular/1982SEA.EVA
+++ b/event/regular/1982SEA.EVA
@@ -10623,7 +10623,7 @@ info,hometeam,SEA
 info,site,SEA02
 info,date,1982/09/06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,true
 info,umphome,sprim901
@@ -10926,7 +10926,7 @@ info,hometeam,SEA
 info,site,SEA02
 info,date,1982/09/08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,true
 info,umphome,brinj901
@@ -11382,7 +11382,7 @@ info,hometeam,SEA
 info,site,SEA02
 info,date,1982/09/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,true
 info,umphome,hendt901

--- a/event/regular/1982SFN.EVN
+++ b/event/regular/1982SFN.EVN
@@ -6,7 +6,7 @@ info,hometeam,SFN
 info,site,SFO02
 info,date,1982/04/13
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,crawj901
@@ -446,7 +446,7 @@ info,hometeam,SFN
 info,site,SFO02
 info,date,1982/04/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,monte901
@@ -613,7 +613,7 @@ info,hometeam,SFN
 info,site,SFO02
 info,date,1982/04/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,marsr901
@@ -1094,7 +1094,7 @@ info,hometeam,SFN
 info,site,SFO02
 info,date,1982/04/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,westj901
@@ -1388,7 +1388,7 @@ info,hometeam,SFN
 info,site,SFO02
 info,date,1982/04/28
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dalej901
@@ -4307,7 +4307,7 @@ info,hometeam,SFN
 info,site,SFO02
 info,date,1982/06/09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,tatat901
@@ -4601,7 +4601,7 @@ info,hometeam,SFN
 info,site,SFO02
 info,date,1982/06/12
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,quicj901
@@ -4783,7 +4783,7 @@ info,hometeam,SFN
 info,site,SFO02
 info,date,1982/06/13
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,kiblj901

--- a/event/regular/1982TEX.EVA
+++ b/event/regular/1982TEX.EVA
@@ -1638,7 +1638,7 @@ info,hometeam,TEX
 info,site,ARL01
 info,date,1982/05/08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,true
 info,umphome,goetr901
@@ -2563,7 +2563,7 @@ info,hometeam,TEX
 info,site,ARL01
 info,date,1982/05/16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,true
 info,umphome,bremn901
@@ -3152,7 +3152,7 @@ info,hometeam,TEX
 info,site,ARL01
 info,date,1982/05/28
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,true
 info,umphome,parkd901
@@ -3287,7 +3287,7 @@ info,hometeam,TEX
 info,site,ARL01
 info,date,1982/05/29
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,true
 info,umphome,sprim901
@@ -4693,7 +4693,7 @@ info,hometeam,TEX
 info,site,ARL01
 info,date,1982/06/13
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,true
 info,umphome,evanj901
@@ -9526,7 +9526,7 @@ info,hometeam,TEX
 info,site,ARL01
 info,date,1982/08/24
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,true
 info,umphome,neudj901
@@ -9811,7 +9811,7 @@ info,hometeam,TEX
 info,site,ARL01
 info,date,1982/08/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,true
 info,umphome,kaisk901

--- a/event/regular/1982TOR.EVA
+++ b/event/regular/1982TOR.EVA
@@ -7180,7 +7180,7 @@ info,hometeam,TOR
 info,site,TOR01
 info,date,1982/07/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,true
 info,umphome,koscg901
@@ -7340,7 +7340,7 @@ info,hometeam,TOR
 info,site,TOR01
 info,date,1982/07/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,true
 info,umphome,pales901

--- a/event/regular/1983ATL.EVN
+++ b/event/regular/1983ATL.EVN
@@ -1981,7 +1981,7 @@ info,hometeam,ATL
 info,site,ATL01
 info,date,1983/05/07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,davis901
@@ -2153,7 +2153,7 @@ info,hometeam,ATL
 info,site,ATL01
 info,date,1983/05/08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,westj901
@@ -5410,7 +5410,7 @@ info,hometeam,ATL
 info,site,ATL01
 info,date,1983/06/12
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,davis901
@@ -5716,7 +5716,7 @@ info,hometeam,ATL
 info,site,ATL01
 info,date,1983/06/29
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,ripps901
@@ -6035,7 +6035,7 @@ info,hometeam,ATL
 info,site,ATL01
 info,date,1983/07/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,demud901
@@ -6182,7 +6182,7 @@ info,hometeam,ATL
 info,site,ATL01
 info,date,1983/07/02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,palld901
@@ -6331,7 +6331,7 @@ info,hometeam,ATL
 info,site,ATL01
 info,date,1983/07/03
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,demud901
@@ -7276,7 +7276,7 @@ info,hometeam,ATL
 info,site,ATL01
 info,date,1983/07/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,dalej901
@@ -7942,7 +7942,7 @@ info,hometeam,ATL
 info,site,ATL01
 info,date,1983/07/23
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,quicj901
@@ -8120,7 +8120,7 @@ info,hometeam,ATL
 info,site,ATL01
 info,date,1983/07/24
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,ripps901
@@ -8433,7 +8433,7 @@ info,hometeam,ATL
 info,site,ATL01
 info,date,1983/08/10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,brocf901
@@ -9061,7 +9061,7 @@ info,hometeam,ATL
 info,site,ATL01
 info,date,1983/08/14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,steld901
@@ -11401,7 +11401,7 @@ info,hometeam,ATL
 info,site,ATL01
 info,date,1983/09/21
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,weyel901
@@ -12071,7 +12071,7 @@ info,hometeam,ATL
 info,site,ATL01
 info,date,1983/09/24
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,kiblj901
@@ -12214,7 +12214,7 @@ info,hometeam,ATL
 info,site,ATL01
 info,date,1983/09/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,froeb901

--- a/event/regular/1983CHN.EVN
+++ b/event/regular/1983CHN.EVN
@@ -290,7 +290,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1983/04/22
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,froeb901
@@ -438,7 +438,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1983/04/23
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,tatat901
@@ -575,7 +575,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1983/04/24
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,willc901
@@ -1242,7 +1242,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1983/04/29
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,davis901
@@ -1393,7 +1393,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1983/04/30
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,westj901
@@ -1535,7 +1535,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1983/05/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,varge901
@@ -1653,7 +1653,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1983/05/12
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,willb901
@@ -1797,7 +1797,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1983/05/13
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mcshj901
@@ -1961,7 +1961,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1983/05/15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,marsr901
@@ -2883,7 +2883,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1983/05/30
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,tatat901
@@ -3253,7 +3253,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1983/06/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,wendh901
@@ -6157,7 +6157,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1983/07/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,quicj901
@@ -6344,7 +6344,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1983/07/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,demud901
@@ -6491,7 +6491,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1983/07/21
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,palld901
@@ -7032,7 +7032,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1983/07/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,kiblj901
@@ -7192,7 +7192,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1983/07/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,wendh901
@@ -7347,7 +7347,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1983/07/27
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,tatat901
@@ -8572,7 +8572,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1983/08/15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,marsr901
@@ -8716,7 +8716,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1983/08/16
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mcshj901
@@ -10093,7 +10093,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1983/09/02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mcshj901
@@ -10447,7 +10447,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1983/09/04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,willc901
@@ -10830,7 +10830,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1983/09/10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,grege901
@@ -11004,7 +11004,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1983/09/11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,pullf901
@@ -12309,7 +12309,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1983/09/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,davis901
@@ -12449,7 +12449,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1983/09/27
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,varge901
@@ -12598,7 +12598,7 @@ info,hometeam,CHN
 info,site,CHI11
 info,date,1983/09/28
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,westj901

--- a/event/regular/1983CIN.EVN
+++ b/event/regular/1983CIN.EVN
@@ -6,7 +6,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1983/04/04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,kiblj901
@@ -145,7 +145,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1983/04/06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,froeb901
@@ -880,7 +880,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1983/04/22
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,monte901
@@ -1013,7 +1013,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1983/04/24
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,harrl901
@@ -2200,7 +2200,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1983/05/15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,harvd901
@@ -3685,7 +3685,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1983/06/05
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,rungp901
@@ -3844,7 +3844,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1983/06/07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,varge901
@@ -3998,7 +3998,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1983/06/08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,steld901
@@ -4152,7 +4152,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1983/06/09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,davis901
@@ -4456,7 +4456,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1983/06/11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,davib902
@@ -4623,7 +4623,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1983/06/12
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,pullf901
@@ -4761,7 +4761,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1983/06/13
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,crawj901
@@ -4904,7 +4904,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1983/06/24
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,monte901
@@ -5039,7 +5039,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1983/06/24
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,harrl901
@@ -5208,7 +5208,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1983/06/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,weyel901
@@ -5359,7 +5359,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1983/06/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,rennd901
@@ -5507,7 +5507,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1983/06/27
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,monte901
@@ -5989,7 +5989,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1983/06/30
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,brocf901
@@ -6464,7 +6464,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1983/07/10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,willc901
@@ -6993,7 +6993,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1983/07/22
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,brocf901
@@ -7158,7 +7158,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1983/07/23
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,marsr901
@@ -7324,7 +7324,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1983/07/24
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,willb901
@@ -7456,7 +7456,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1983/07/25
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,palld901
@@ -7887,7 +7887,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1983/07/27
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,rungp901
@@ -8511,7 +8511,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1983/08/12
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,varge901
@@ -8796,7 +8796,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1983/08/14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,ripps901
@@ -11257,7 +11257,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1983/09/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,davis901
@@ -11571,7 +11571,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1983/09/24
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,weyel901
@@ -11713,7 +11713,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1983/09/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,rennd901
@@ -12425,7 +12425,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1983/09/29
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,willc901

--- a/event/regular/1983HOU.EVN
+++ b/event/regular/1983HOU.EVN
@@ -2274,7 +2274,7 @@ info,hometeam,HOU
 info,site,HOU02
 info,date,1983/04/24
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,willb901
@@ -3423,7 +3423,7 @@ info,hometeam,HOU
 info,site,HOU02
 info,date,1983/05/15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,tatat901
@@ -4620,7 +4620,7 @@ info,hometeam,HOU
 info,site,HOU02
 info,date,1983/05/29
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,palld901
@@ -6858,7 +6858,7 @@ info,hometeam,HOU
 info,site,HOU02
 info,date,1983/07/12
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,wendh901
@@ -7723,7 +7723,7 @@ info,hometeam,HOU
 info,site,HOU02
 info,date,1983/07/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,davis901
@@ -8749,7 +8749,7 @@ info,hometeam,HOU
 info,site,HOU02
 info,date,1983/08/10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,steld901
@@ -9267,7 +9267,7 @@ info,hometeam,HOU
 info,site,HOU02
 info,date,1983/08/13
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,davig901
@@ -12147,7 +12147,7 @@ info,hometeam,HOU
 info,site,HOU02
 info,date,1983/09/29
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,harrl901
@@ -12454,7 +12454,7 @@ info,hometeam,HOU
 info,site,HOU02
 info,date,1983/10/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mcshj901

--- a/event/regular/1983LAN.EVN
+++ b/event/regular/1983LAN.EVN
@@ -6,7 +6,7 @@ info,hometeam,LAN
 info,site,LOS03
 info,date,1983/04/08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,davis901
@@ -158,7 +158,7 @@ info,hometeam,LAN
 info,site,LOS03
 info,date,1983/04/09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,westj901
@@ -309,7 +309,7 @@ info,hometeam,LAN
 info,site,LOS03
 info,date,1983/04/10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,varge901
@@ -1291,7 +1291,7 @@ info,hometeam,LAN
 info,site,LOS03
 info,date,1983/04/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,wendh901
@@ -3003,7 +3003,7 @@ info,hometeam,LAN
 info,site,LOS03
 info,date,1983/05/28
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,rennd901
@@ -3138,7 +3138,7 @@ info,hometeam,LAN
 info,site,LOS03
 info,date,1983/05/29
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,davib902
@@ -4247,7 +4247,7 @@ info,hometeam,LAN
 info,site,LOS03
 info,date,1983/06/05
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,rennd901
@@ -6209,7 +6209,7 @@ info,hometeam,LAN
 info,site,LOS03
 info,date,1983/06/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,froeb901
@@ -9775,7 +9775,7 @@ info,hometeam,LAN
 info,site,LOS03
 info,date,1983/08/21
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,tatat901
@@ -12204,7 +12204,7 @@ info,hometeam,LAN
 info,site,LOS03
 info,date,1983/10/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,rungp901
@@ -12353,7 +12353,7 @@ info,hometeam,LAN
 info,site,LOS03
 info,date,1983/10/02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,quicj901

--- a/event/regular/1983MIN.EVA
+++ b/event/regular/1983MIN.EVA
@@ -607,7 +607,7 @@ info,hometeam,MIN
 info,site,MIN03
 info,date,1983/04/16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,true
 info,umphome,malog901
@@ -744,7 +744,7 @@ info,hometeam,MIN
 info,site,MIN03
 info,date,1983/04/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,true
 info,umphome,pales901

--- a/event/regular/1983MON.EVN
+++ b/event/regular/1983MON.EVN
@@ -752,7 +752,7 @@ info,hometeam,MON
 info,site,MON02
 info,date,1983/04/29
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,rungp901
@@ -919,7 +919,7 @@ info,hometeam,MON
 info,site,MON02
 info,date,1983/04/30
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,quicj901
@@ -1079,7 +1079,7 @@ info,hometeam,MON
 info,site,MON02
 info,date,1983/05/01
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,palld901
@@ -1240,7 +1240,7 @@ info,hometeam,MON
 info,site,MON02
 info,date,1983/05/01
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,engeb901
@@ -1831,7 +1831,7 @@ info,hometeam,MON
 info,site,MON02
 info,date,1983/05/07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,rennd901
@@ -2203,7 +2203,7 @@ info,hometeam,MON
 info,site,MON02
 info,date,1983/05/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,westj901
@@ -2515,7 +2515,7 @@ info,hometeam,MON
 info,site,MON02
 info,date,1983/05/21
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dalej901
@@ -2656,7 +2656,7 @@ info,hometeam,MON
 info,site,MON02
 info,date,1983/05/22
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,pullf901
@@ -3729,7 +3729,7 @@ info,hometeam,MON
 info,site,MON02
 info,date,1983/06/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,willb901
@@ -4046,7 +4046,7 @@ info,hometeam,MON
 info,site,MON02
 info,date,1983/06/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,brocf901
@@ -7091,7 +7091,7 @@ info,hometeam,MON
 info,site,MON02
 info,date,1983/07/24
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,davib902
@@ -10371,7 +10371,7 @@ info,hometeam,MON
 info,site,MON02
 info,date,1983/09/04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,davib902
@@ -11033,7 +11033,7 @@ info,hometeam,MON
 info,site,MON02
 info,date,1983/09/09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,willb901
@@ -11200,7 +11200,7 @@ info,hometeam,MON
 info,site,MON02
 info,date,1983/09/10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,mcshj901
@@ -11372,7 +11372,7 @@ info,hometeam,MON
 info,site,MON02
 info,date,1983/09/11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,marsr901

--- a/event/regular/1983NYN.EVN
+++ b/event/regular/1983NYN.EVN
@@ -6,7 +6,7 @@ info,hometeam,NYN
 info,site,NYC17
 info,date,1983/04/05
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,harvd901
@@ -142,7 +142,7 @@ info,hometeam,NYN
 info,site,NYC17
 info,date,1983/04/07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dalej901
@@ -3389,7 +3389,7 @@ info,hometeam,NYN
 info,site,NYC17
 info,date,1983/06/10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,brocf901
@@ -3641,7 +3641,7 @@ info,hometeam,NYN
 info,site,NYC17
 info,date,1983/06/11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,willb901
@@ -3802,7 +3802,7 @@ info,hometeam,NYN
 info,site,NYC17
 info,date,1983/06/12
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mcshj901
@@ -4766,7 +4766,7 @@ info,hometeam,NYN
 info,site,NYC17
 info,date,1983/06/21
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,willc901
@@ -5181,7 +5181,7 @@ info,hometeam,NYN
 info,site,NYC17
 info,date,1983/06/23
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,tatat901
@@ -5505,7 +5505,7 @@ info,hometeam,NYN
 info,site,NYC17
 info,date,1983/06/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mcshj901
@@ -5826,7 +5826,7 @@ info,hometeam,NYN
 info,site,NYC17
 info,date,1983/06/26
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,davig901
@@ -6276,7 +6276,7 @@ info,hometeam,NYN
 info,site,NYC17
 info,date,1983/07/10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,steld901
@@ -6440,7 +6440,7 @@ info,hometeam,NYN
 info,site,NYC17
 info,date,1983/07/12
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,willb901
@@ -6589,7 +6589,7 @@ info,hometeam,NYN
 info,site,NYC17
 info,date,1983/07/13
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,mcshj901
@@ -6730,7 +6730,7 @@ info,hometeam,NYN
 info,site,NYC17
 info,date,1983/07/14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,brocf901
@@ -6887,7 +6887,7 @@ info,hometeam,NYN
 info,site,NYC17
 info,date,1983/07/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,crawj901
@@ -7055,7 +7055,7 @@ info,hometeam,NYN
 info,site,NYC17
 info,date,1983/07/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,pullf901
@@ -7214,7 +7214,7 @@ info,hometeam,NYN
 info,site,NYC17
 info,date,1983/07/27
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,davib902
@@ -8216,7 +8216,7 @@ info,hometeam,NYN
 info,site,NYC17
 info,date,1983/08/02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,monte901
@@ -8368,7 +8368,7 @@ info,hometeam,NYN
 info,site,NYC17
 info,date,1983/08/03
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,weyel901
@@ -8503,7 +8503,7 @@ info,hometeam,NYN
 info,site,NYC17
 info,date,1983/08/04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,davig901
@@ -9397,7 +9397,7 @@ info,hometeam,NYN
 info,site,NYC17
 info,date,1983/08/28
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,willc901
@@ -10331,7 +10331,7 @@ info,hometeam,NYN
 info,site,NYC17
 info,date,1983/09/02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,weyel901
@@ -10480,7 +10480,7 @@ info,hometeam,NYN
 info,site,NYC17
 info,date,1983/09/03
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,rennd901
@@ -10722,7 +10722,7 @@ info,hometeam,NYN
 info,site,NYC17
 info,date,1983/09/04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,harrl901
@@ -11381,7 +11381,7 @@ info,hometeam,NYN
 info,site,NYC17
 info,date,1983/09/14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,monte901
@@ -11541,7 +11541,7 @@ info,hometeam,NYN
 info,site,NYC17
 info,date,1983/09/15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,weyel901
@@ -12556,7 +12556,7 @@ info,hometeam,NYN
 info,site,NYC17
 info,date,1983/10/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,steld901
@@ -12707,7 +12707,7 @@ info,hometeam,NYN
 info,site,NYC17
 info,date,1983/10/02
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,davis901
@@ -12828,7 +12828,7 @@ info,hometeam,NYN
 info,site,NYC17
 info,date,1983/10/02
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,varge901

--- a/event/regular/1983PHI.EVN
+++ b/event/regular/1983PHI.EVN
@@ -184,7 +184,7 @@ info,hometeam,PHI
 info,site,PHI12
 info,date,1983/04/13
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,umphome,weyel901
 info,ump1b,harrl901
@@ -544,7 +544,7 @@ info,hometeam,PHI
 info,site,PHI12
 info,date,1983/04/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,tatat901
@@ -1151,7 +1151,7 @@ info,hometeam,PHI
 info,site,PHI12
 info,date,1983/04/30
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,crawj901
@@ -1294,7 +1294,7 @@ info,hometeam,PHI
 info,site,PHI12
 info,date,1983/05/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,harvd901
@@ -3171,7 +3171,7 @@ info,hometeam,PHI
 info,site,PHI12
 info,date,1983/05/29
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,willb901
@@ -4170,7 +4170,7 @@ info,hometeam,PHI
 info,site,PHI12
 info,date,1983/06/12
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,tatat901
@@ -4847,7 +4847,7 @@ info,hometeam,PHI
 info,site,PHI12
 info,date,1983/06/30
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,rungp901
@@ -5464,7 +5464,7 @@ info,hometeam,PHI
 info,site,PHI12
 info,date,1983/07/03
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,crawj901
@@ -7766,7 +7766,7 @@ info,hometeam,PHI
 info,site,PHI12
 info,date,1983/07/31
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,davig901
@@ -8849,7 +8849,7 @@ info,hometeam,PHI
 info,site,PHI12
 info,date,1983/08/14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,crawj901
@@ -9014,7 +9014,7 @@ info,hometeam,PHI
 info,site,PHI12
 info,date,1983/08/26
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,palld901
@@ -9298,7 +9298,7 @@ info,hometeam,PHI
 info,site,PHI12
 info,date,1983/08/28
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,quicj901
@@ -10706,7 +10706,7 @@ info,hometeam,PHI
 info,site,PHI12
 info,date,1983/09/04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,davis901
@@ -11850,7 +11850,7 @@ info,hometeam,PHI
 info,site,PHI12
 info,date,1983/09/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,kiblj901
@@ -11988,7 +11988,7 @@ info,hometeam,PHI
 info,site,PHI12
 info,date,1983/09/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,froeb901
@@ -12871,7 +12871,7 @@ info,hometeam,PHI
 info,site,PHI12
 info,date,1983/10/02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,tatat901

--- a/event/regular/1983PIT.EVN
+++ b/event/regular/1983PIT.EVN
@@ -3671,7 +3671,7 @@ info,hometeam,PIT
 info,site,PIT07
 info,date,1983/06/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,davis901
@@ -3991,7 +3991,7 @@ info,hometeam,PIT
 info,site,PIT07
 info,date,1983/06/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,varge901
@@ -10883,7 +10883,7 @@ info,hometeam,PIT
 info,site,PIT07
 info,date,1983/09/11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,weyel901

--- a/event/regular/1983SDN.EVN
+++ b/event/regular/1983SDN.EVN
@@ -311,7 +311,7 @@ info,hometeam,SDN
 info,site,SAN01
 info,date,1983/04/14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,westj901
@@ -2085,7 +2085,7 @@ info,hometeam,SDN
 info,site,SAN01
 info,date,1983/05/12
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,engeb901
@@ -2526,7 +2526,7 @@ info,hometeam,SDN
 info,site,SAN01
 info,date,1983/05/15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,palld901
@@ -3571,7 +3571,7 @@ info,hometeam,SDN
 info,site,SAN01
 info,date,1983/06/02
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,willb901
@@ -4096,7 +4096,7 @@ info,hometeam,SDN
 info,site,SAN01
 info,date,1983/06/05
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,brocf901
@@ -4232,7 +4232,7 @@ info,hometeam,SDN
 info,site,SAN01
 info,date,1983/06/14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,willc901
@@ -4392,7 +4392,7 @@ info,hometeam,SDN
 info,site,SAN01
 info,date,1983/06/15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,wendh901
@@ -4529,7 +4529,7 @@ info,hometeam,SDN
 info,site,SAN01
 info,date,1983/06/16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,froeb901
@@ -4958,7 +4958,7 @@ info,hometeam,SDN
 info,site,SAN01
 info,date,1983/06/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,quicj901
@@ -5446,7 +5446,7 @@ info,hometeam,SDN
 info,site,SAN01
 info,date,1983/06/30
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,davig901
@@ -5919,7 +5919,7 @@ info,hometeam,SDN
 info,site,SAN01
 info,date,1983/07/03
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,willc901
@@ -8963,7 +8963,7 @@ info,hometeam,SDN
 info,site,SAN01
 info,date,1983/08/04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,tatat901
@@ -9095,7 +9095,7 @@ info,hometeam,SDN
 info,site,SAN01
 info,date,1983/08/05
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,engeb901
@@ -9255,7 +9255,7 @@ info,hometeam,SDN
 info,site,SAN01
 info,date,1983/08/06
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,quicj901
@@ -9564,7 +9564,7 @@ info,hometeam,SDN
 info,site,SAN01
 info,date,1983/08/07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,palld901
@@ -9867,7 +9867,7 @@ info,hometeam,SDN
 info,site,SAN01
 info,date,1983/08/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,crawj901
@@ -10783,7 +10783,7 @@ info,hometeam,SDN
 info,site,SAN01
 info,date,1983/08/24
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,mcshj901
@@ -11070,7 +11070,7 @@ info,hometeam,SDN
 info,site,SAN01
 info,date,1983/09/08
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,davis901
@@ -11378,7 +11378,7 @@ info,hometeam,SDN
 info,site,SAN01
 info,date,1983/09/11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,engeb901

--- a/event/regular/1983SFN.EVN
+++ b/event/regular/1983SFN.EVN
@@ -6,7 +6,7 @@ info,hometeam,SFN
 info,site,SFO02
 info,date,1983/04/05
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,varge901
@@ -479,7 +479,7 @@ info,hometeam,SFN
 info,site,SFO02
 info,date,1983/04/09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mcshj901
@@ -661,7 +661,7 @@ info,hometeam,SFN
 info,site,SFO02
 info,date,1983/04/10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,marsr901
@@ -1151,7 +1151,7 @@ info,hometeam,SFN
 info,site,SFO02
 info,date,1983/04/17
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,monte901
@@ -1910,7 +1910,7 @@ info,hometeam,SFN
 info,site,SFO02
 info,date,1983/05/04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,quicj901
@@ -3434,7 +3434,7 @@ info,hometeam,SFN
 info,site,SFO02
 info,date,1983/06/03
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,steld901
@@ -3581,7 +3581,7 @@ info,hometeam,SFN
 info,site,SFO02
 info,date,1983/06/04
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,davis901
@@ -3726,7 +3726,7 @@ info,hometeam,SFN
 info,site,SFO02
 info,date,1983/06/05
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,westj901
@@ -4084,7 +4084,7 @@ info,hometeam,SFN
 info,site,SFO02
 info,date,1983/06/15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,davib902
@@ -4535,7 +4535,7 @@ info,hometeam,SFN
 info,site,SFO02
 info,date,1983/06/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,weyel901
@@ -4689,7 +4689,7 @@ info,hometeam,SFN
 info,site,SFO02
 info,date,1983/06/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,rennd901
@@ -5290,7 +5290,7 @@ info,hometeam,SFN
 info,site,SFO02
 info,date,1983/06/22
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,rungp901
@@ -5575,7 +5575,7 @@ info,hometeam,SFN
 info,site,SFO02
 info,date,1983/06/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,demud901
@@ -5728,7 +5728,7 @@ info,hometeam,SFN
 info,site,SFO02
 info,date,1983/06/26
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,engeb901
@@ -6163,7 +6163,7 @@ info,hometeam,SFN
 info,site,SFO02
 info,date,1983/07/09
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,harrl901
@@ -6325,7 +6325,7 @@ info,hometeam,SFN
 info,site,SFO02
 info,date,1983/07/10
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,weyel901
@@ -7453,7 +7453,7 @@ info,hometeam,SFN
 info,site,SFO02
 info,date,1983/07/16
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,engeb901
@@ -7630,7 +7630,7 @@ info,hometeam,SFN
 info,site,SFO02
 info,date,1983/07/17
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,palld901
@@ -7902,7 +7902,7 @@ info,hometeam,SFN
 info,site,SFO02
 info,date,1983/07/30
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,kiblj901
@@ -8054,7 +8054,7 @@ info,hometeam,SFN
 info,site,SFO02
 info,date,1983/07/31
 info,number,1
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,wendh901
@@ -8670,7 +8670,7 @@ info,hometeam,SFN
 info,site,SFO02
 info,date,1983/08/03
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,rungp901
@@ -9153,7 +9153,7 @@ info,hometeam,SFN
 info,site,SFO02
 info,date,1983/08/06
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,davis901
@@ -9307,7 +9307,7 @@ info,hometeam,SFN
 info,site,SFO02
 info,date,1983/08/07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,varge901
@@ -9944,7 +9944,7 @@ info,hometeam,SFN
 info,site,SFO02
 info,date,1983/08/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,monte901
@@ -10082,7 +10082,7 @@ info,hometeam,SFN
 info,site,SFO02
 info,date,1983/08/21
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,rennd901
@@ -10575,7 +10575,7 @@ info,hometeam,SFN
 info,site,SFO02
 info,date,1983/08/24
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,harvd901
@@ -10718,7 +10718,7 @@ info,hometeam,SFN
 info,site,SFO02
 info,date,1983/09/05
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,varge901
@@ -11543,7 +11543,7 @@ info,hometeam,SFN
 info,site,SFO02
 info,date,1983/09/10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,tatat901
@@ -12116,7 +12116,7 @@ info,hometeam,SFN
 info,site,SFO02
 info,date,1983/09/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,mcshj901
@@ -12618,7 +12618,7 @@ info,hometeam,SFN
 info,site,SFO02
 info,date,1983/09/21
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,willb901

--- a/event/regular/1983SLN.EVN
+++ b/event/regular/1983SLN.EVN
@@ -1319,7 +1319,7 @@ info,hometeam,SLN
 info,site,STL09
 info,date,1983/04/27
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,monte901
@@ -1900,7 +1900,7 @@ info,hometeam,SLN
 info,site,STL09
 info,date,1983/05/01
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,marsr901
@@ -2878,7 +2878,7 @@ info,hometeam,SLN
 info,site,STL09
 info,date,1983/05/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,palld901
@@ -5884,7 +5884,7 @@ info,hometeam,SLN
 info,site,STL09
 info,date,1983/06/29
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,harvd901
@@ -6051,7 +6051,7 @@ info,hometeam,SLN
 info,site,STL09
 info,date,1983/06/30
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,crawj901
@@ -7002,7 +7002,7 @@ info,hometeam,SLN
 info,site,STL09
 info,date,1983/07/24
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,froeb901
@@ -7454,7 +7454,7 @@ info,hometeam,SLN
 info,site,STL09
 info,date,1983/07/27
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,dalej901
@@ -8482,7 +8482,7 @@ info,hometeam,SLN
 info,site,STL09
 info,date,1983/08/07
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,weyel901
@@ -9392,7 +9392,7 @@ info,hometeam,SLN
 info,site,STL09
 info,date,1983/08/21
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,palld901
@@ -11148,7 +11148,7 @@ info,hometeam,SLN
 info,site,STL09
 info,date,1983/09/21
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,steld901
@@ -11304,7 +11304,7 @@ info,hometeam,SLN
 info,site,STL09
 info,date,1983/09/22
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,davis901
@@ -11614,7 +11614,7 @@ info,hometeam,SLN
 info,site,STL09
 info,date,1983/09/24
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,engeb901
@@ -11799,7 +11799,7 @@ info,hometeam,SLN
 info,site,STL09
 info,date,1983/09/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,palld901

--- a/event/regular/1995PHI.EVN
+++ b/event/regular/1995PHI.EVN
@@ -610,7 +610,7 @@ info,hometeam,PHI
 info,site,PHI12
 info,date,1995/05/11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,vanol901

--- a/event/regular/1995SLN.EVN
+++ b/event/regular/1995SLN.EVN
@@ -174,7 +174,7 @@ info,hometeam,SLN
 info,site,STL09
 info,date,1995/04/27
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,davib901

--- a/event/regular/1996CIN.EVN
+++ b/event/regular/1996CIN.EVN
@@ -1541,7 +1541,7 @@ info,hometeam,CIN
 info,site,CIN08
 info,date,1996/04/14
 info,number,2
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,vanol901

--- a/event/regular/1996HOU.EVN
+++ b/event/regular/1996HOU.EVN
@@ -11146,7 +11146,7 @@ info,hometeam,HOU
 info,site,HOU02
 info,date,1996/09/10
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,ripps901
@@ -11280,7 +11280,7 @@ info,hometeam,HOU
 info,site,HOU02
 info,date,1996/09/11
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,willc901

--- a/event/regular/1996LAN.EVN
+++ b/event/regular/1996LAN.EVN
@@ -8934,7 +8934,7 @@ info,hometeam,LAN
 info,site,LOS03
 info,date,1996/08/20
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,rungp901
@@ -9073,7 +9073,7 @@ info,hometeam,LAN
 info,site,LOS03
 info,date,1996/08/21
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,westj901
@@ -9192,7 +9192,7 @@ info,hometeam,LAN
 info,site,LOS03
 info,date,1996/08/22
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,kellj901

--- a/event/regular/1996NYN.EVN
+++ b/event/regular/1996NYN.EVN
@@ -11599,7 +11599,7 @@ info,hometeam,NYN
 info,site,NYC17
 info,date,1996/09/14
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,ripps901

--- a/event/regular/1996PHI.EVN
+++ b/event/regular/1996PHI.EVN
@@ -8812,7 +8812,7 @@ info,hometeam,PHI
 info,site,PHI12
 info,date,1996/08/15
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,hallt901
@@ -9319,7 +9319,7 @@ info,hometeam,PHI
 info,site,PHI12
 info,date,1996/08/18
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,poncl901
@@ -11414,7 +11414,7 @@ info,hometeam,PHI
 info,site,PHI12
 info,date,1996/09/19
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,willc901
@@ -11831,7 +11831,7 @@ info,hometeam,PHI
 info,site,PHI12
 info,date,1996/09/22
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,night
 info,usedh,false
 info,umphome,hohnb901

--- a/event/regular/1996SDN.EVN
+++ b/event/regular/1996SDN.EVN
@@ -10447,7 +10447,7 @@ info,hometeam,SDN
 info,site,SAN01
 info,date,1996/08/25
 info,number,0
-info,starttime,0:00
+info,starttime,0:00PM
 info,daynight,day
 info,usedh,false
 info,umphome,westj901


### PR DESCRIPTION
Not entirely sure how you might feel about this one, but I noticed that many of the event files had missing start times but actually reported them as "0:00AM", "0:00PM", "0:00", and "00:00".

~~Because other records in the `info` block just don't show up if the data are missing, I thought that it might be best to simply remove these lines where the data were actually missing, rather than reporting them (inconsistently).~~

Update: Per @tturocy's comments below, this PR now makes these missing start times consistent as `0:00PM`.