### PR TITLE
Fixed bad AM/PM designation in starttime

### DIFF
--- a/event/regular/2001MIN.EVA
+++ b/event/regular/2001MIN.EVA
@@ -8041,7 +8041,7 @@ info,hometeam,MIN
 info,site,MIN03
 info,date,2001/08/04
 info,number,0
-info,starttime,6:06Ac
+info,starttime,6:06PM
 info,daynight,night
 info,usedh,true
 info,umphome,cuzzp901


### PR DESCRIPTION
I noticed that in the `2001MIN.EVA` event file, there is a starttime that is designated "6:06Ac" instead of "6:06PM", this PR fixes that.