### PR TITLE
Fix OBA 1967

### DIFF
--- a/event/regular/1967WS2.EVA
+++ b/event/regular/1967WS2.EVA
@@ -497,7 +497,7 @@ play,1,0,bufod101,??,,W
 play,1,0,berrk101,??,,SB2
 play,1,0,berrk101,??,,W
 play,1,0,mccrt102,??,,8.2-3;1-2
-play,1,0,ageet101,??,,K23+OBA/DP.3XH(32)
+play,1,0,ageet101,??,,K23+OA/DP.3XH(32)
 play,1,1,brine101,??,,K
 play,1,1,alleb105,??,,K
 play,1,1,valef101,??,,W


### PR DESCRIPTION
Small fix for 1967 Washington; OA incorrectly encoded as OBA